### PR TITLE
Add `schema` RPC

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,22776 @@
+{
+  "rpcs": {
+    "abandontransaction": {
+      "category": "wallet",
+      "description": "\nMark in-wallet transaction <txid> as abandoned\nThis will mark this transaction and all its in-wallet descendants as abandoned which will allow\nfor their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\nIt only works on transactions which are not included in a block and are not currently in the mempool.\nIt has no effect on transactions which are already abandoned.\n",
+      "examples": "> bitcoin-cli abandontransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"abandontransaction\", \"params\": [\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "abandontransaction",
+      "argument_names": [
+        "txid"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "abortrescan": {
+      "category": "wallet",
+      "description": "\nStops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.\nNote: Use \"getwalletinfo\" to query the scanning progress.\n",
+      "examples": "\nImport a private key\n> bitcoin-cli importprivkey \"mykey\"\n\nAbort the running wallet rescan\n> bitcoin-cli abortrescan \n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"abortrescan\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "abortrescan",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "Whether the abort was successful",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "addconnection": {
+      "category": "hidden",
+      "description": "\nOpen an outbound connection to a specified node. This RPC is for testing only.\n",
+      "examples": "> bitcoin-cli addconnection \"192.168.0.6:8333\" \"outbound-full-relay\" true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"addconnection\", \"params\": [\"192.168.0.6:8333\" \"outbound-full-relay\" true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "addconnection",
+      "argument_names": [
+        "address",
+        "connection_type",
+        "v2transport"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The IP address and port to attempt connecting to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "connection_type"
+          ],
+          "description": "Type of connection to open (\"outbound-full-relay\", \"block-relay-only\", \"addr-fetch\" or \"feeler\").",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "v2transport"
+          ],
+          "description": "Attempt to connect using BIP324 v2 transport protocol",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Address of newly added connection.",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Type of connection opened.",
+              "skip_type_check": false,
+              "key_name": "connection_type",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "addmultisigaddress": {
+      "category": "wallet",
+      "description": "\nAdd an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.\nEach key is a Bitcoin address or hex-encoded public key.\nThis functionality is only intended for use with non-watchonly addresses.\nSee `importaddress` for watchonly p2sh address support.\nIf 'label' is specified, assign address to that label.\nNote: This command is only compatible with legacy wallets.\n",
+      "examples": "\nAdd a multisig address from 2 addresses\n> bitcoin-cli addmultisigaddress 2 \"[\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\",\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\"]\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"addmultisigaddress\", \"params\": [2, \"[\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\",\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\"]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "addmultisigaddress",
+      "argument_names": [
+        "nrequired",
+        "keys",
+        "label",
+        "address_type"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "nrequired"
+          ],
+          "description": "The number of required signatures out of the n keys or addresses.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "keys"
+          ],
+          "description": "The bitcoin addresses or hex-encoded public keys",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "key"
+              ],
+              "description": "bitcoin address or hex-encoded public key",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "A label to assign the addresses to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "address_type"
+          ],
+          "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "set by -addresstype",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The value of the new multisig address",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The string value of the hex-encoded redemption script",
+              "skip_type_check": false,
+              "key_name": "redeemScript",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The descriptor for this multisig",
+              "skip_type_check": false,
+              "key_name": "descriptor",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Any warnings resulting from the creation of this multisig",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "addnode": {
+      "category": "network",
+      "description": "\nAttempts to add or remove a node from the addnode list.\nOr try a connection to a node once.\nNodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be\nfull nodes/support SegWit as other outbound peers are (though such peers will not be synced from).\nAddnode connections are limited to 8 at a time and are counted separately from the -maxconnections limit.\n",
+      "examples": "> bitcoin-cli addnode \"192.168.0.6:8333\" \"onetry\" true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"addnode\", \"params\": [\"192.168.0.6:8333\", \"onetry\" true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "addnode",
+      "argument_names": [
+        "node",
+        "command",
+        "v2transport"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "node"
+          ],
+          "description": "The address of the peer to connect to",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "command"
+          ],
+          "description": "'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "v2transport"
+          ],
+          "description": "Attempt to connect using BIP324 v2 transport protocol (ignored for 'remove' command)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "set by -v2transport",
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "addpeeraddress": {
+      "category": "hidden",
+      "description": "Add the address of a potential peer to an address manager table. This RPC is for testing only.",
+      "examples": "> bitcoin-cli addpeeraddress \"1.2.3.4\" 8333 true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"addpeeraddress\", \"params\": [\"1.2.3.4\", 8333, true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "addpeeraddress",
+      "argument_names": [
+        "address",
+        "port",
+        "tried"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The IP address of the peer",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "port"
+          ],
+          "description": "The port of the peer",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "tried"
+          ],
+          "description": "If true, attempt to add the peer to the tried addresses table",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "whether the peer address was successfully added to the address manager table",
+              "skip_type_check": false,
+              "key_name": "success",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "error description, if the address could not be added",
+              "skip_type_check": false,
+              "key_name": "error",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "analyzepsbt": {
+      "category": "rawtransactions",
+      "description": "\nAnalyzes and provides information about the current status of a PSBT and its inputs\n",
+      "examples": "> bitcoin-cli analyzepsbt \"psbt\"\n",
+      "name": "analyzepsbt",
+      "argument_names": [
+        "psbt"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "A base64 string of a PSBT",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": true,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "inputs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "Whether a UTXO is provided",
+                      "skip_type_check": false,
+                      "key_name": "has_utxo",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "Whether the input is finalized",
+                      "skip_type_check": false,
+                      "key_name": "is_final",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "Things that are missing that are required to complete this input",
+                      "skip_type_check": false,
+                      "key_name": "missing",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "array",
+                          "optional": true,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "pubkeys",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "Public key ID, hash160 of the public key, of a public key whose BIP 32 derivation path is missing",
+                              "skip_type_check": false,
+                              "key_name": "keyid",
+                              "condition": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "optional": true,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "signatures",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "Public key ID, hash160 of the public key, of a public key whose signature is missing",
+                              "skip_type_check": false,
+                              "key_name": "keyid",
+                              "condition": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "hex",
+                          "optional": true,
+                          "description": "Hash160 of the redeem script that is missing",
+                          "skip_type_check": false,
+                          "key_name": "redeemscript",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": true,
+                          "description": "SHA256 of the witness script that is missing",
+                          "skip_type_check": false,
+                          "key_name": "witnessscript",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "Role of the next person that this input needs to go to",
+                      "skip_type_check": false,
+                      "key_name": "next",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Estimated vsize of the final signed transaction",
+              "skip_type_check": false,
+              "key_name": "estimated_vsize",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": true,
+              "description": "Estimated feerate of the final signed transaction in BTC/kvB. Shown only if all UTXO slots in the PSBT have been filled",
+              "skip_type_check": false,
+              "key_name": "estimated_feerate",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": true,
+              "description": "The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Role of the next person that this psbt needs to go to",
+              "skip_type_check": false,
+              "key_name": "next",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "Error message (if there is one)",
+              "skip_type_check": false,
+              "key_name": "error",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "backupwallet": {
+      "category": "wallet",
+      "description": "\nSafely copies the current wallet file to the specified destination, which can either be a directory or a path with a filename.\n",
+      "examples": "> bitcoin-cli backupwallet \"backup.dat\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"backupwallet\", \"params\": [\"backup.dat\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "backupwallet",
+      "argument_names": [
+        "destination"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "destination"
+          ],
+          "description": "The destination directory or file",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "bumpfee": {
+      "category": "wallet",
+      "description": "\nBumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B.\nAn opt-in RBF transaction with the given txid must be in the wallet.\nThe command will pay the additional fee by reducing change outputs or adding inputs when necessary.\nIt may add a new change output if one does not already exist.\nAll inputs in the original transaction will be included in the replacement transaction.\nThe command will fail if the wallet or mempool contains a transaction that spends one of T's outputs.\nBy default, the new fee will be calculated automatically using the estimatesmartfee RPC.\nThe user can specify a confirmation target for estimatesmartfee.\nAlternatively, the user can specify a fee rate in sat/vB for the new transaction.\nAt a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee\nreturned by getnetworkinfo) to enter the node's mempool.\n* WARNING: before version 0.21, fee_rate was in BTC/kvB. As of 0.21, fee_rate is in sat/vB. *\n",
+      "examples": "\nBump the fee, get the new transaction's txid\n> bitcoin-cli bumpfee <txid>\n",
+      "name": "bumpfee",
+      "argument_names": [
+        "txid",
+        "conf_target",
+        "fee_rate",
+        "replaceable",
+        "estimate_mode",
+        "outputs",
+        "original_change_index",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The txid to be bumped",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "\nSpecify a fee rate in sat/vB instead of relying on the built-in fee estimator.\nMust be at least 1.000 sat/vB higher than the current transaction fee rate.\nWARNING: before version 0.21, fee_rate was in BTC/kvB. As of 0.21, fee_rate is in sat/vB.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Whether the new transaction should still be\nmarked bip-125 replaceable. If true, the sequence numbers in the transaction will\nbe left unchanged from the original. If false, any input sequence numbers in the\noriginal transaction that were less than 0xfffffffe will be increased to 0xfffffffe\nso the new transaction will not be explicitly bip-125 replaceable (though it may\nstill be replaceable in practice, for example if it has unconfirmed ancestors which\nare replaceable).\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "outputs"
+              ],
+              "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nCannot be provided if 'original_change_index' is specified.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "address"
+                      ],
+                      "description": "A key-value pair. The key (string) is the bitcoin address,\nthe value (float or string) is the amount in BTC",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "amount"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "data"
+                      ],
+                      "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "names": [
+                "original_change_index"
+              ],
+              "description": "The 0-based index of the change output on the original transaction. The indicated output will be recycled into the new change output on the bumped transaction. The remainder after paying the recipients and fees will be sent to the output script of the original change output. The change output’s amount can increase if bumping the transaction adds new inputs, otherwise it will decrease. Cannot be used in combination with the 'outputs' option.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, detect change automatically",
+              "hidden": false,
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The id of the new transaction.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The fee of the replaced transaction.",
+              "skip_type_check": false,
+              "key_name": "origfee",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The fee of the new transaction.",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Errors encountered during processing (may be empty).",
+              "skip_type_check": false,
+              "key_name": "errors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "clearbanned": {
+      "category": "network",
+      "description": "\nClear all banned IPs.\n",
+      "examples": "> bitcoin-cli clearbanned \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"clearbanned\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "clearbanned",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "combinepsbt": {
+      "category": "rawtransactions",
+      "description": "\nCombine multiple partially signed Bitcoin transactions into one transaction.\nImplements the Combiner role.\n",
+      "examples": "> bitcoin-cli combinepsbt '[\"mybase64_1\", \"mybase64_2\", \"mybase64_3\"]'\n",
+      "name": "combinepsbt",
+      "argument_names": [
+        "txs"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txs"
+          ],
+          "description": "The base64 strings of partially signed transactions",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "psbt"
+              ],
+              "description": "A base64 string of a PSBT",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The base64-encoded partially signed transaction",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "combinerawtransaction": {
+      "category": "rawtransactions",
+      "description": "\nCombine multiple partially signed transactions into one transaction.\nThe combined transaction may be another partially signed transaction or a \nfully signed transaction.",
+      "examples": "> bitcoin-cli combinerawtransaction '[\"myhex1\", \"myhex2\", \"myhex3\"]'\n",
+      "name": "combinerawtransaction",
+      "argument_names": [
+        "txs"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txs"
+          ],
+          "description": "The hex strings of partially signed transactions",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "hexstring"
+              ],
+              "description": "A hex-encoded raw transaction",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The hex-encoded raw transaction with signature(s)",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "converttopsbt": {
+      "category": "rawtransactions",
+      "description": "\nConverts a network serialized transaction to a PSBT. This should be used only with createrawtransaction and fundrawtransaction\ncreatepsbt and walletcreatefundedpsbt should be used for new applications.\n",
+      "examples": "\nCreate a transaction\n> bitcoin-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"\n\nConvert the transaction to a PSBT\n> bitcoin-cli converttopsbt \"rawtransaction\"\n",
+      "name": "converttopsbt",
+      "argument_names": [
+        "hexstring",
+        "permitsigdata",
+        "iswitness"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The hex string of a raw transaction",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "permitsigdata"
+          ],
+          "description": "If true, any signatures in the input will be discarded and conversion\n                              will continue. If false, RPC will fail if any signatures are present.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "iswitness"
+          ],
+          "description": "Whether the transaction hex is a serialized witness transaction.\nIf iswitness is not present, heuristic tests will be used in decoding.\nIf true, only witness deserialization will be tried.\nIf false, only non-witness deserialization will be tried.\nThis boolean should reflect whether the transaction has inputs\n(e.g. fully valid, or on-chain transactions), if known by the caller.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "depends on heuristic tests",
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The resulting raw transaction (base64-encoded string)",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "createmultisig": {
+      "category": "util",
+      "description": "\nCreates a multi-signature address with n signature of m keys required.\nIt returns a json object with the address and redeemScript.\n",
+      "examples": "\nCreate a multisig address from 2 public keys\n> bitcoin-cli createmultisig 2 \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createmultisig\", \"params\": [2, [\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\",\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "createmultisig",
+      "argument_names": [
+        "nrequired",
+        "keys",
+        "address_type"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "nrequired"
+          ],
+          "description": "The number of required signatures out of the n keys.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "keys"
+          ],
+          "description": "The hex-encoded public keys.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "key"
+              ],
+              "description": "The hex-encoded public key",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "address_type"
+          ],
+          "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "legacy",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The value of the new multisig address.",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The string value of the hex-encoded redemption script.",
+              "skip_type_check": false,
+              "key_name": "redeemScript",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The descriptor for this multisig",
+              "skip_type_check": false,
+              "key_name": "descriptor",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Any warnings resulting from the creation of this multisig",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "createpsbt": {
+      "category": "rawtransactions",
+      "description": "\nCreates a transaction in the Partially Signed Transaction format.\nImplements the Creator role.\n",
+      "examples": "> bitcoin-cli createpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"\n",
+      "name": "createpsbt",
+      "argument_names": [
+        "inputs",
+        "outputs",
+        "locktime",
+        "replaceable"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "inputs"
+          ],
+          "description": "The inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "sequence"
+                  ],
+                  "description": "The sequence number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default_hint": "depends on the value of the 'replaceable' and 'locktime' arguments",
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "outputs"
+          ],
+          "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nFor compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n                             accepted as second parameter.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "address"
+                  ],
+                  "description": "A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in BTC",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "data"
+                  ],
+                  "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "locktime"
+          ],
+          "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "replaceable"
+          ],
+          "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The resulting raw transaction (base64-encoded string)",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "createrawtransaction": {
+      "category": "rawtransactions",
+      "description": "\nCreate a transaction spending the given inputs and creating new outputs.\nOutputs can be addresses or data.\nReturns hex-encoded raw transaction.\nNote that the transaction's inputs are not signed, and\nit is not stored in the wallet or transmitted to the network.\n",
+      "examples": "> bitcoin-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"address\\\":0.01}]\"\n> bitcoin-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"address\\\":0.01}]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"data\\\":\\\"00010203\\\"}]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "createrawtransaction",
+      "argument_names": [
+        "inputs",
+        "outputs",
+        "locktime",
+        "replaceable"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "inputs"
+          ],
+          "description": "The inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "sequence"
+                  ],
+                  "description": "The sequence number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default_hint": "depends on the value of the 'replaceable' and 'locktime' arguments",
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "outputs"
+          ],
+          "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nFor compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n                             accepted as second parameter.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "address"
+                  ],
+                  "description": "A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in BTC",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "data"
+                  ],
+                  "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "locktime"
+          ],
+          "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "replaceable"
+          ],
+          "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "hex string of the transaction",
+          "skip_type_check": false,
+          "key_name": "transaction",
+          "condition": ""
+        }
+      ]
+    },
+    "createwallet": {
+      "category": "wallet",
+      "description": "\nCreates and loads a new wallet.\n",
+      "examples": "> bitcoin-cli createwallet \"testwallet\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createwallet\", \"params\": [\"testwallet\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli -named createwallet wallet_name=descriptors avoid_reuse=true descriptors=true load_on_startup=true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createwallet\", \"params\": {\"wallet_name\":\"descriptors\",\"avoid_reuse\":true,\"descriptors\":true,\"load_on_startup\":true}}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "createwallet",
+      "argument_names": [
+        "wallet_name",
+        "disable_private_keys",
+        "blank",
+        "passphrase",
+        "avoid_reuse",
+        "descriptors",
+        "load_on_startup",
+        "external_signer"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "wallet_name"
+          ],
+          "description": "The name for the new wallet. If this is a path, the wallet will be created at the path location.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "disable_private_keys"
+          ],
+          "description": "Disable the possibility of private keys (only watchonlys are possible in this mode).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "blank"
+          ],
+          "description": "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using sethdseed.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "passphrase"
+          ],
+          "description": "Encrypt the wallet with this passphrase.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "avoid_reuse"
+          ],
+          "description": "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "descriptors"
+          ],
+          "description": "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation. Setting to \"false\" will create a legacy wallet; This is only possible with the -deprecatedrpc=create_bdb setting because, the legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "load_on_startup"
+          ],
+          "description": "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "external_signer"
+          ],
+          "description": "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The wallet name if created successfully. If the wallet was created using a full path, the wallet_name will be the full path.",
+              "skip_type_check": false,
+              "key_name": "name",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Warning messages, if any, related to creating and loading the wallet.",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "createwalletdescriptor": {
+      "category": "wallet",
+      "description": "Creates the wallet's descriptor for the given address type. The address type must be one that the wallet does not already have a descriptor for.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "> bitcoin-cli createwalletdescriptor bech32m\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"createwalletdescriptor\", \"params\": [bech32m]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "createwalletdescriptor",
+      "argument_names": [
+        "type",
+        "internal",
+        "hdkey",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "type"
+          ],
+          "description": "The address type the descriptor will produce. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "internal"
+              ],
+              "description": "Whether to only make one descriptor that is internal (if parameter is true) or external (if parameter is false)",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "Both external and internal will be generated unless this parameter is specified",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "hdkey"
+              ],
+              "description": "The HD key that the wallet knows the private key of, listed using 'gethdkeys', to use for this descriptor's key",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "The HD key used by all other active descriptors",
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "The public descriptors that were added to the wallet",
+              "skip_type_check": false,
+              "key_name": "descs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "decodepsbt": {
+      "category": "rawtransactions",
+      "description": "Return a JSON object representing the serialized, base64-encoded partially signed Bitcoin transaction.",
+      "examples": "> bitcoin-cli decodepsbt \"psbt\"\n",
+      "name": "decodepsbt",
+      "argument_names": [
+        "psbt"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "The PSBT base64 string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "The decoded network-serialized unsigned transaction.",
+              "skip_type_check": false,
+              "key_name": "tx",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "The layout is the same as the output of decoderawtransaction.",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "global_xpubs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The extended public key this path corresponds to",
+                      "skip_type_check": false,
+                      "key_name": "xpub",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The fingerprint of the master key",
+                      "skip_type_check": false,
+                      "key_name": "master_fingerprint",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The path",
+                      "skip_type_check": false,
+                      "key_name": "path",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The PSBT version number. Not to be confused with the unsigned transaction version",
+              "skip_type_check": false,
+              "key_name": "psbt_version",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "The global proprietary map",
+              "skip_type_check": false,
+              "key_name": "proprietary",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hex string for the proprietary identifier",
+                      "skip_type_check": false,
+                      "key_name": "identifier",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The number for the subtype",
+                      "skip_type_check": false,
+                      "key_name": "subtype",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hex for the key",
+                      "skip_type_check": false,
+                      "key_name": "key",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hex for the value",
+                      "skip_type_check": false,
+                      "key_name": "value",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "The unknown global fields",
+              "skip_type_check": false,
+              "key_name": "unknown",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "(key-value pair) An unknown key-value pair",
+                  "skip_type_check": false,
+                  "key_name": "key",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "inputs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "Decoded network transaction for non-witness UTXOs",
+                      "skip_type_check": false,
+                      "key_name": "non_witness_utxo",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "elision",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "Transaction output for witness UTXOs",
+                      "skip_type_check": false,
+                      "key_name": "witness_utxo",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "The value in BTC",
+                          "skip_type_check": false,
+                          "key_name": "amount",
+                          "condition": ""
+                        },
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "scriptPubKey",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "Disassembly of the output script",
+                              "skip_type_check": false,
+                              "key_name": "asm",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "Inferred descriptor for the output",
+                              "skip_type_check": false,
+                              "key_name": "desc",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The raw output script bytes, hex-encoded",
+                              "skip_type_check": false,
+                              "key_name": "hex",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The type, eg 'pubkeyhash'",
+                              "skip_type_check": false,
+                              "key_name": "type",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": true,
+                              "description": "The Bitcoin address (only if a well-defined address exists)",
+                              "skip_type_check": false,
+                              "key_name": "address",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "partial_signatures",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The public key and signature that corresponds to it.",
+                          "skip_type_check": false,
+                          "key_name": "pubkey",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "The sighash type to be used",
+                      "skip_type_check": false,
+                      "key_name": "sighash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "redeem_script",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the redeem script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw redeem script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type, eg 'pubkeyhash'",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "witness_script",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the witness script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw witness script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type, eg 'pubkeyhash'",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "bip32_derivs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The public key with the derivation path as the value.",
+                              "skip_type_check": false,
+                              "key_name": "pubkey",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The fingerprint of the master key",
+                              "skip_type_check": false,
+                              "key_name": "master_fingerprint",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The path",
+                              "skip_type_check": false,
+                              "key_name": "path",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "final_scriptSig",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the final signature script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw final signature script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "final_scriptwitness",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "hex-encoded witness data (if any)",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "ripemd160_preimages",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The hash and preimage that corresponds to it.",
+                          "skip_type_check": false,
+                          "key_name": "hash",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "sha256_preimages",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The hash and preimage that corresponds to it.",
+                          "skip_type_check": false,
+                          "key_name": "hash",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "hash160_preimages",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The hash and preimage that corresponds to it.",
+                          "skip_type_check": false,
+                          "key_name": "hash",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "hash256_preimages",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The hash and preimage that corresponds to it.",
+                          "skip_type_check": false,
+                          "key_name": "hash",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "hex-encoded signature for the Taproot key path spend",
+                      "skip_type_check": false,
+                      "key_name": "taproot_key_path_sig",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "taproot_script_path_sigs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": true,
+                          "description": "The signature for the pubkey and leaf hash combination",
+                          "skip_type_check": false,
+                          "key_name": "signature",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The x-only pubkey for this signature",
+                              "skip_type_check": false,
+                              "key_name": "pubkey",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The leaf hash for this signature",
+                              "skip_type_check": false,
+                              "key_name": "leaf_hash",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The signature itself",
+                              "skip_type_check": false,
+                              "key_name": "sig",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "taproot_scripts",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "A leaf script",
+                              "skip_type_check": false,
+                              "key_name": "script",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "The version number for the leaf script",
+                              "skip_type_check": false,
+                              "key_name": "leaf_ver",
+                              "condition": ""
+                            },
+                            {
+                              "type": "array",
+                              "optional": false,
+                              "description": "The control blocks for this script",
+                              "skip_type_check": false,
+                              "key_name": "control_blocks",
+                              "condition": "",
+                              "inner": [
+                                {
+                                  "type": "hex",
+                                  "optional": false,
+                                  "description": "A hex-encoded control block for this script",
+                                  "skip_type_check": false,
+                                  "key_name": "control_block",
+                                  "condition": ""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "taproot_bip32_derivs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The x-only public key this path corresponds to",
+                              "skip_type_check": false,
+                              "key_name": "pubkey",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The fingerprint of the master key",
+                              "skip_type_check": false,
+                              "key_name": "master_fingerprint",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The path",
+                              "skip_type_check": false,
+                              "key_name": "path",
+                              "condition": ""
+                            },
+                            {
+                              "type": "array",
+                              "optional": false,
+                              "description": "The hashes of the leaves this pubkey appears in",
+                              "skip_type_check": false,
+                              "key_name": "leaf_hashes",
+                              "condition": "",
+                              "inner": [
+                                {
+                                  "type": "hex",
+                                  "optional": false,
+                                  "description": "The hash of a leaf this pubkey appears in",
+                                  "skip_type_check": false,
+                                  "key_name": "hash",
+                                  "condition": ""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The hex-encoded Taproot x-only internal key",
+                      "skip_type_check": false,
+                      "key_name": "taproot_internal_key",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The hex-encoded Taproot merkle root",
+                      "skip_type_check": false,
+                      "key_name": "taproot_merkle_root",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "The unknown input fields",
+                      "skip_type_check": false,
+                      "key_name": "unknown",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "(key-value pair) An unknown key-value pair",
+                          "skip_type_check": false,
+                          "key_name": "key",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "The input proprietary map",
+                      "skip_type_check": false,
+                      "key_name": "proprietary",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex string for the proprietary identifier",
+                              "skip_type_check": false,
+                              "key_name": "identifier",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "The number for the subtype",
+                              "skip_type_check": false,
+                              "key_name": "subtype",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex for the key",
+                              "skip_type_check": false,
+                              "key_name": "key",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex for the value",
+                              "skip_type_check": false,
+                              "key_name": "value",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "outputs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "redeem_script",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the redeem script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw redeem script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type, eg 'pubkeyhash'",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "witness_script",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the witness script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw witness script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type, eg 'pubkeyhash'",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "bip32_derivs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The public key this path corresponds to",
+                              "skip_type_check": false,
+                              "key_name": "pubkey",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The fingerprint of the master key",
+                              "skip_type_check": false,
+                              "key_name": "master_fingerprint",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The path",
+                              "skip_type_check": false,
+                              "key_name": "path",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The hex-encoded Taproot x-only internal key",
+                      "skip_type_check": false,
+                      "key_name": "taproot_internal_key",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "The tuples that make up the Taproot tree, in depth first search order",
+                      "skip_type_check": false,
+                      "key_name": "taproot_tree",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": true,
+                          "description": "A single leaf script in the taproot tree",
+                          "skip_type_check": false,
+                          "key_name": "tuple",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "The depth of this element in the tree",
+                              "skip_type_check": false,
+                              "key_name": "depth",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "The version of this leaf",
+                              "skip_type_check": false,
+                              "key_name": "leaf_ver",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The hex-encoded script itself",
+                              "skip_type_check": false,
+                              "key_name": "script",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "taproot_bip32_derivs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The x-only public key this path corresponds to",
+                              "skip_type_check": false,
+                              "key_name": "pubkey",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The fingerprint of the master key",
+                              "skip_type_check": false,
+                              "key_name": "master_fingerprint",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The path",
+                              "skip_type_check": false,
+                              "key_name": "path",
+                              "condition": ""
+                            },
+                            {
+                              "type": "array",
+                              "optional": false,
+                              "description": "The hashes of the leaves this pubkey appears in",
+                              "skip_type_check": false,
+                              "key_name": "leaf_hashes",
+                              "condition": "",
+                              "inner": [
+                                {
+                                  "type": "hex",
+                                  "optional": false,
+                                  "description": "The hash of a leaf this pubkey appears in",
+                                  "skip_type_check": false,
+                                  "key_name": "hash",
+                                  "condition": ""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "The unknown output fields",
+                      "skip_type_check": false,
+                      "key_name": "unknown",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "(key-value pair) An unknown key-value pair",
+                          "skip_type_check": false,
+                          "key_name": "key",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "The output proprietary map",
+                      "skip_type_check": false,
+                      "key_name": "proprietary",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex string for the proprietary identifier",
+                              "skip_type_check": false,
+                              "key_name": "identifier",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "The number for the subtype",
+                              "skip_type_check": false,
+                              "key_name": "subtype",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex for the key",
+                              "skip_type_check": false,
+                              "key_name": "key",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The hex for the value",
+                              "skip_type_check": false,
+                              "key_name": "value",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "amount",
+              "optional": true,
+              "description": "The transaction fee paid if all UTXOs slots in the PSBT have been filled.",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "decoderawtransaction": {
+      "category": "rawtransactions",
+      "description": "Return a JSON object representing the serialized, hex-encoded transaction.",
+      "examples": "> bitcoin-cli decoderawtransaction \"hexstring\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"decoderawtransaction\", \"params\": [\"hexstring\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "decoderawtransaction",
+      "argument_names": [
+        "hexstring",
+        "iswitness"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The transaction hex string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "iswitness"
+          ],
+          "description": "Whether the transaction hex is a serialized witness transaction.\nIf iswitness is not present, heuristic tests will be used in decoding.\nIf true, only witness deserialization will be tried.\nIf false, only non-witness deserialization will be tried.\nThis boolean should reflect whether the transaction has inputs\n(e.g. fully valid, or on-chain transactions), if known by the caller.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "depends on heuristic tests",
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction hash (differs from txid for witness transactions)",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The serialized transaction size",
+              "skip_type_check": false,
+              "key_name": "size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The virtual transaction size (differs from size for witness transactions)",
+              "skip_type_check": false,
+              "key_name": "vsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The transaction's weight (between vsize*4-3 and vsize*4)",
+              "skip_type_check": false,
+              "key_name": "weight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The lock time",
+              "skip_type_check": false,
+              "key_name": "locktime",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "vin",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The coinbase value (only if coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "coinbase",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The transaction id (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The output number (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "The script (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "scriptSig",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the signature script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw signature script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "txinwitness",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "hex-encoded witness data (if any)",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The script sequence number",
+                      "skip_type_check": false,
+                      "key_name": "sequence",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "vout",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The value in BTC",
+                      "skip_type_check": false,
+                      "key_name": "value",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "index",
+                      "skip_type_check": false,
+                      "key_name": "n",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "scriptPubKey",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the output script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Inferred descriptor for the output",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw output script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": true,
+                          "description": "The Bitcoin address (only if a well-defined address exists)",
+                          "skip_type_check": false,
+                          "key_name": "address",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "decodescript": {
+      "category": "rawtransactions",
+      "description": "\nDecode a hex-encoded script.\n",
+      "examples": "> bitcoin-cli decodescript \"hexstring\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"decodescript\", \"params\": [\"hexstring\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "decodescript",
+      "argument_names": [
+        "hexstring"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "the hex-encoded script",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Disassembly of the script",
+              "skip_type_check": false,
+              "key_name": "asm",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Inferred descriptor for the script",
+              "skip_type_check": false,
+              "key_name": "desc",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The output type (e.g. nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+              "skip_type_check": false,
+              "key_name": "type",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The Bitcoin address (only if a well-defined address exists)",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "address of P2SH script wrapping this redeem script (not returned for types that should not be wrapped)",
+              "skip_type_check": false,
+              "key_name": "p2sh",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "Result of a witness output script wrapping this redeem script (not returned for types that should not be wrapped)",
+              "skip_type_check": false,
+              "key_name": "segwit",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Disassembly of the output script",
+                  "skip_type_check": false,
+                  "key_name": "asm",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The raw output script bytes, hex-encoded",
+                  "skip_type_check": false,
+                  "key_name": "hex",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The type of the output script (e.g. witness_v0_keyhash or witness_v0_scripthash)",
+                  "skip_type_check": false,
+                  "key_name": "type",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "The Bitcoin address (only if a well-defined address exists)",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Inferred descriptor for the script",
+                  "skip_type_check": false,
+                  "key_name": "desc",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "address of the P2SH script wrapping this witness redeem script",
+                  "skip_type_check": false,
+                  "key_name": "p2sh-segwit",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "deriveaddresses": {
+      "category": "util",
+      "description": "\nDerives one or more addresses corresponding to an output descriptor.\nExamples of output descriptors are:\n    pkh(<pubkey>)                                     P2PKH outputs for the given pubkey\n    wpkh(<pubkey>)                                    Native segwit P2PKH outputs for the given pubkey\n    sh(multi(<n>,<pubkey>,<pubkey>,...))              P2SH-multisig outputs for the given threshold and pubkeys\n    raw(<hex script>)                                 Outputs whose output script equals the specified hex-encoded bytes\n    tr(<pubkey>,multi_a(<n>,<pubkey>,<pubkey>,...))   P2TR-multisig outputs for the given threshold and pubkeys\n\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\nor more path elements separated by \"/\", where \"h\" represents a hardened child key.\nFor more information on output descriptors, see the documentation in the doc/descriptors.md file.\n",
+      "examples": "First three native segwit receive addresses\n> bitcoin-cli deriveaddresses \"wpkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)#cjjspncu\" \"[0,2]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"deriveaddresses\", \"params\": [\"wpkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)#cjjspncu\", \"[0,2]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "deriveaddresses",
+      "argument_names": [
+        "descriptor",
+        "range"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "descriptor"
+          ],
+          "description": "The descriptor.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "range"
+          ],
+          "description": "If a ranged descriptor is used, this specifies the end or the range (in [begin,end] notation) to derive.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "range"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for single derivation descriptors",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the derived addresses",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "optional": false,
+          "description": "The derived addresses for each of the multipath expansions of the descriptor, in multipath specifier order",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for multipath descriptors",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "The derived addresses for a multipath descriptor expansion",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "the derived address",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "descriptorprocesspsbt": {
+      "category": "rawtransactions",
+      "description": "\nUpdate all segwit inputs in a PSBT with information from output descriptors, the UTXO set or the mempool. \nThen, sign the inputs we are able to with information from the output descriptors. ",
+      "examples": "> bitcoin-cli descriptorprocesspsbt \"psbt\" \"[\\\"descriptor1\\\", \\\"descriptor2\\\"]\"\n> bitcoin-cli descriptorprocesspsbt \"psbt\" \"[{\\\"desc\\\":\\\"mydescriptor\\\", \\\"range\\\":21}]\"\n",
+      "name": "descriptorprocesspsbt",
+      "argument_names": [
+        "psbt",
+        "descriptors",
+        "sighashtype",
+        "bip32derivs",
+        "finalize"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "The transaction base64 string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "descriptors"
+          ],
+          "description": "An array of either strings or objects",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "An output descriptor",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "An object with an output descriptor and extra information",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "An output descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "Up to what index HD chains should be explored (either end or [begin,end])",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": 1000,
+                  "hidden": false,
+                  "type": "range"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "sighashtype"
+          ],
+          "description": "The signature hash type to sign with if not specified by the PSBT. Must be one of\n       \"DEFAULT\"\n       \"ALL\"\n       \"NONE\"\n       \"SINGLE\"\n       \"ALL|ANYONECANPAY\"\n       \"NONE|ANYONECANPAY\"\n       \"SINGLE|ANYONECANPAY\"",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "DEFAULT for Taproot, ALL otherwise",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "bip32derivs"
+          ],
+          "description": "Include BIP 32 derivation paths for public keys if we know them",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "finalize"
+          ],
+          "description": "Also finalize inputs if possible",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The base64-encoded partially signed transaction",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex-encoded network transaction if complete",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "disconnectnode": {
+      "category": "network",
+      "description": "\nImmediately disconnects from the specified peer node.\n\nStrictly one out of 'address' and 'nodeid' can be provided to identify the node.\n\nTo disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.\n",
+      "examples": "> bitcoin-cli disconnectnode \"192.168.0.6:8333\"\n> bitcoin-cli disconnectnode \"\" 1\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"disconnectnode\", \"params\": [\"192.168.0.6:8333\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"disconnectnode\", \"params\": [\"\", 1]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "disconnectnode",
+      "argument_names": [
+        "address",
+        "nodeid"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The IP address/port of the node",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "fallback to nodeid",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "nodeid"
+          ],
+          "description": "The node ID (see getpeerinfo for node IDs)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "fallback to address",
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "dumpprivkey": {
+      "category": "wallet",
+      "description": "\nReveals the private key corresponding to 'address'.\nThen the importprivkey can be used with this output\nNote: This command is only compatible with legacy wallets.\n",
+      "examples": "> bitcoin-cli dumpprivkey \"myaddress\"\n> bitcoin-cli importprivkey \"mykey\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"dumpprivkey\", \"params\": [\"myaddress\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "dumpprivkey",
+      "argument_names": [
+        "address"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address for the private key",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The private key",
+          "skip_type_check": false,
+          "key_name": "key",
+          "condition": ""
+        }
+      ]
+    },
+    "dumptxoutset": {
+      "category": "blockchain",
+      "description": "Write the serialized UTXO set to a file. This can be used in loadtxoutset afterwards if this snapshot height is supported in the chainparams as well.\n\nUnless the \"latest\" type is requested, the node will roll back to the requested height and network activity will be suspended during this process. Because of this it is discouraged to interact with the node in any other way during the execution of this call to avoid inconsistent results and race conditions, particularly RPCs that interact with blockstorage.\n\nThis call may take several minutes. Make sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli -rpcclienttimeout=0 dumptxoutset utxo.dat latest\n> bitcoin-cli -rpcclienttimeout=0 dumptxoutset utxo.dat rollback\n> bitcoin-cli -rpcclienttimeout=0 -named dumptxoutset utxo.dat rollback=853456\n",
+      "name": "dumptxoutset",
+      "argument_names": [
+        "path",
+        "type",
+        "rollback",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "path"
+          ],
+          "description": "Path to the output file. If relative, will be prefixed by datadir.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "type"
+          ],
+          "description": "The type of snapshot to create. Can be \"latest\" to create a snapshot of the current UTXO set or \"rollback\" to temporarily roll back the state of the node to a historical block before creating the snapshot of a historical UTXO set. This parameter can be omitted if a separate \"rollback\" named parameter is specified indicating the height or hash of a specific historical block. If \"rollback\" is specified and separate \"rollback\" named parameter is not specified, this will roll back to the latest valid snapshot block that can currently be loaded with loadtxoutset.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "rollback"
+              ],
+              "description": "Height or hash of the block to roll back to before creating the snapshot. Note: The further this number is from the tip, the longer this process will take. Consider setting a higher -rpcclienttimeout value in this case.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [
+                "",
+                "string or numeric"
+              ],
+              "required": false,
+              "hidden": false,
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of coins written in the snapshot",
+              "skip_type_check": false,
+              "key_name": "coins_written",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the hash of the base of the snapshot",
+              "skip_type_check": false,
+              "key_name": "base_hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the height of the base of the snapshot",
+              "skip_type_check": false,
+              "key_name": "base_height",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the absolute path that the snapshot was written to",
+              "skip_type_check": false,
+              "key_name": "path",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the hash of the UTXO set contents",
+              "skip_type_check": false,
+              "key_name": "txoutset_hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of transactions in the chain up to and including the base block",
+              "skip_type_check": false,
+              "key_name": "nchaintx",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "dumpwallet": {
+      "category": "wallet",
+      "description": "\nDumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\nImported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet.\nNote that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by\nonly backing up the seed itself, and must be backed up too (e.g. ensure you back up the whole dumpfile).\nNote: This command is only compatible with legacy wallets.\n",
+      "examples": "> bitcoin-cli dumpwallet \"test\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"dumpwallet\", \"params\": [\"test\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "dumpwallet",
+      "argument_names": [
+        "filename"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "filename"
+          ],
+          "description": "The filename with path (absolute path recommended)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The filename with full absolute path",
+              "skip_type_check": false,
+              "key_name": "filename",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "echo": {
+      "category": "hidden",
+      "description": "\nSimply echo back the input arguments. This command is for testing.\n\nIt will return an internal bug report when arg9='trigger_internal_bug' is passed.\n\nThe difference between echo and echojson is that echojson has argument conversion enabled in the client-side table in bitcoin-cli and the GUI. There is no server-side difference.",
+      "examples": "",
+      "name": "echo",
+      "argument_names": [
+        "arg0",
+        "arg1",
+        "arg2",
+        "arg3",
+        "arg4",
+        "arg5",
+        "arg6",
+        "arg7",
+        "arg8",
+        "arg9"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "arg0"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg1"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg2"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg3"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg4"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg5"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg6"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg7"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg8"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg9"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "any",
+          "optional": false,
+          "description": "Returns whatever was passed in",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "echoipc": {
+      "category": "hidden",
+      "description": "\nEcho back the input argument, passing it through a spawned process in a multiprocess build.\nThis command is for testing.\n",
+      "examples": "> bitcoin-cli echo \"Hello world\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"echo\", \"params\": [\"Hello world\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "echoipc",
+      "argument_names": [
+        "arg"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "arg"
+          ],
+          "description": "The string to echo",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The echoed string.",
+          "skip_type_check": false,
+          "key_name": "echo",
+          "condition": ""
+        }
+      ]
+    },
+    "echojson": {
+      "category": "hidden",
+      "description": "\nSimply echo back the input arguments. This command is for testing.\n\nIt will return an internal bug report when arg9='trigger_internal_bug' is passed.\n\nThe difference between echo and echojson is that echojson has argument conversion enabled in the client-side table in bitcoin-cli and the GUI. There is no server-side difference.",
+      "examples": "",
+      "name": "echojson",
+      "argument_names": [
+        "arg0",
+        "arg1",
+        "arg2",
+        "arg3",
+        "arg4",
+        "arg5",
+        "arg6",
+        "arg7",
+        "arg8",
+        "arg9"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "arg0"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg1"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg2"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg3"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg4"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg5"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg6"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg7"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg8"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "arg9"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "any",
+          "optional": false,
+          "description": "Returns whatever was passed in",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "encryptwallet": {
+      "category": "wallet",
+      "description": "\nEncrypts the wallet with 'passphrase'. This is for first time encryption.\nAfter this, any calls that interact with private keys such as sending or signing \nwill require the passphrase to be set prior the making these calls.\nUse the walletpassphrase call for this, and then walletlock call.\nIf the wallet is already encrypted, use the walletpassphrasechange call.\n** IMPORTANT **\nFor security reasons, the encryption process will generate a new HD seed, resulting\nin the creation of a fresh set of active descriptors. Therefore, it is crucial to\nsecurely back up the newly generated wallet file using the backupwallet RPC.\n",
+      "examples": "\nEncrypt your wallet\n> bitcoin-cli encryptwallet \"my pass phrase\"\n\nNow set the passphrase to use the wallet, such as for signing or sending bitcoin\n> bitcoin-cli walletpassphrase \"my pass phrase\"\n\nNow we can do something like sign\n> bitcoin-cli signmessage \"address\" \"test message\"\n\nNow lock the wallet again by removing the passphrase\n> bitcoin-cli walletlock \n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"encryptwallet\", \"params\": [\"my pass phrase\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "encryptwallet",
+      "argument_names": [
+        "passphrase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "passphrase"
+          ],
+          "description": "The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "A string with further instructions",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "enumeratesigners": {
+      "category": "signer",
+      "description": "Returns a list of external signers from -signer.",
+      "examples": "> bitcoin-cli enumeratesigners \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"enumeratesigners\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "enumeratesigners",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "signers",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "Master key fingerprint",
+                      "skip_type_check": false,
+                      "key_name": "fingerprint",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "Device name",
+                      "skip_type_check": false,
+                      "key_name": "name",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "estimaterawfee": {
+      "category": "hidden",
+      "description": "\nWARNING: This interface is unstable and may disappear or change!\n\nWARNING: This is an advanced API call that is tightly coupled to the specific\nimplementation of fee estimation. The parameters it can be called with\nand the results it returns will change if the internal implementation changes.\n\nEstimates the approximate fee per kilobyte needed for a transaction to begin\nconfirmation within conf_target blocks if possible. Uses virtual transaction size as\ndefined in BIP 141 (witness data is discounted).\n",
+      "examples": "> bitcoin-cli estimaterawfee 6 0.9\n",
+      "name": "estimaterawfee",
+      "argument_names": [
+        "conf_target",
+        "threshold"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks (1 - 1008)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "threshold"
+          ],
+          "description": "The proportion of transactions in a given feerate range that must have been\nconfirmed within conf_target in order to consider those feerates as high enough and proceed to check\nlower buckets.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0.95,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "Results are returned for any horizon which tracks blocks up to the confirmation target",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": true,
+              "description": "estimate for short time horizon",
+              "skip_type_check": false,
+              "key_name": "short",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "estimate fee rate in BTC/kvB",
+                  "skip_type_check": false,
+                  "key_name": "feerate",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "exponential decay (per block) for historical moving average of confirmation data",
+                  "skip_type_check": false,
+                  "key_name": "decay",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The resolution of confirmation targets at this time horizon",
+                  "skip_type_check": false,
+                  "key_name": "scale",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": true,
+                  "description": "information about the lowest range of feerates to succeed in meeting the threshold",
+                  "skip_type_check": false,
+                  "key_name": "pass",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "start of feerate range",
+                      "skip_type_check": false,
+                      "key_name": "startrange",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "end of feerate range",
+                      "skip_type_check": false,
+                      "key_name": "endrange",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "number of txs over history horizon in the feerate range that were confirmed within target",
+                      "skip_type_check": false,
+                      "key_name": "withintarget",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "number of txs over history horizon in the feerate range that were confirmed at any point",
+                      "skip_type_check": false,
+                      "key_name": "totalconfirmed",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "current number of txs in mempool in the feerate range unconfirmed for at least target blocks",
+                      "skip_type_check": false,
+                      "key_name": "inmempool",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "number of txs over history horizon in the feerate range that left mempool unconfirmed after target",
+                      "skip_type_check": false,
+                      "key_name": "leftmempool",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "optional": true,
+                  "description": "information about the highest range of feerates to fail to meet the threshold",
+                  "skip_type_check": false,
+                  "key_name": "fail",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "elision",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": true,
+                  "description": "Errors encountered during processing (if there are any)",
+                  "skip_type_check": false,
+                  "key_name": "errors",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "error",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "estimate for medium time horizon",
+              "skip_type_check": false,
+              "key_name": "medium",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "estimate for long time horizon",
+              "skip_type_check": false,
+              "key_name": "long",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "estimatesmartfee": {
+      "category": "util",
+      "description": "\nEstimates the approximate fee per kilobyte needed for a transaction to begin\nconfirmation within conf_target blocks if possible and return the number of blocks\nfor which the estimate is valid. Uses virtual transaction size as defined\nin BIP 141 (witness data is discounted).\n",
+      "examples": "> bitcoin-cli estimatesmartfee 6\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"estimatesmartfee\", \"params\": [6]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "estimatesmartfee",
+      "argument_names": [
+        "conf_target",
+        "estimate_mode"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks (1 - 1008)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "estimate_mode"
+          ],
+          "description": "The fee estimate mode.\nunset, economical, conservative \nunset means no mode set (default mode will be used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "economical",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": true,
+              "description": "estimate fee rate in BTC/kvB (only present if no errors were encountered)",
+              "skip_type_check": false,
+              "key_name": "feerate",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Errors encountered during processing (if there are any)",
+              "skip_type_check": false,
+              "key_name": "errors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "error",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "block number where estimate was found\nThe request target will be clamped between 2 and the highest target\nfee estimation is able to return based on how long it has been running.\nAn error is returned if not enough transactions and blocks\nhave been observed to make an estimate for any number of blocks.",
+              "skip_type_check": false,
+              "key_name": "blocks",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "finalizepsbt": {
+      "category": "rawtransactions",
+      "description": "Finalize the inputs of a PSBT. If the transaction is fully signed, it will produce a\nnetwork serialized transaction which can be broadcast with sendrawtransaction. Otherwise a PSBT will be\ncreated which has the final_scriptSig and final_scriptWitness fields filled for inputs that are complete.\nImplements the Finalizer and Extractor roles.\n",
+      "examples": "> bitcoin-cli finalizepsbt \"psbt\"\n",
+      "name": "finalizepsbt",
+      "argument_names": [
+        "psbt",
+        "extract"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "A base64 string of a PSBT",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "extract"
+          ],
+          "description": "If true and the transaction is complete,\n                             extract and return the complete transaction in normal network serialization instead of the PSBT.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The base64-encoded partially signed transaction if not extracted",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex-encoded network transaction if extracted",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "fundrawtransaction": {
+      "category": "rawtransactions",
+      "description": "\nIf the transaction has no inputs, they will be automatically selected to meet its out value.\nIt will add at most one change output to the outputs.\nNo existing outputs will be modified unless \"subtractFeeFromOutputs\" is specified.\nNote that inputs which were signed may need to be resigned after completion since in/outputs have been added.\nThe inputs added will not be signed, use signrawtransactionwithkey\nor signrawtransactionwithwallet for that.\nAll existing inputs must either have their previous output transaction be in the wallet\nor be in the UTXO set. Solving data must be provided for non-wallet inputs.\nNote that all inputs selected must be of standard form and P2SH scripts must be\nin the wallet using importaddress or addmultisigaddress (to calculate fees).\nYou can see whether this is the case by checking the \"solvable\" field in the listunspent output.\nOnly pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only\n",
+      "examples": "\nCreate a transaction with no inputs\n> bitcoin-cli createrawtransaction \"[]\" \"{\\\"myaddress\\\":0.01}\"\n\nAdd sufficient unsigned inputs to meet the output value\n> bitcoin-cli fundrawtransaction \"rawtransactionhex\"\n\nSign the transaction\n> bitcoin-cli signrawtransactionwithwallet \"fundedtransactionhex\"\n\nSend the transaction\n> bitcoin-cli sendrawtransaction \"signedtransactionhex\"\n",
+      "name": "fundrawtransaction",
+      "argument_names": [
+        "hexstring",
+        "add_inputs",
+        "include_unsafe",
+        "minconf",
+        "maxconf",
+        "changeAddress",
+        "changePosition",
+        "change_type",
+        "includeWatching",
+        "lockUnspents",
+        "fee_rate",
+        "feeRate",
+        "subtractFeeFromOutputs",
+        "input_weights",
+        "max_tx_weight",
+        "conf_target",
+        "estimate_mode",
+        "replaceable",
+        "solving_data",
+        "options",
+        "iswitness"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The hex string of the raw transaction",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "For backward compatibility: passing in a true instead of an object will result in {\"includeWatching\":true}",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "add_inputs"
+              ],
+              "description": "For a transaction with existing inputs, automatically include more if they are not enough.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "include_unsafe"
+              ],
+              "description": "Include inputs that are not safe to spend (unconfirmed transactions from outside keys and unconfirmed replacement transactions).\nWarning: the resulting transaction may become invalid if one of the unsafe inputs disappears.\nIf that happens, you will need to fund the transaction with different inputs and republish it.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "minconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at least this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "maxconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at most this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "changeAddress"
+              ],
+              "description": "The bitcoin address to receive the change",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "automatic",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "changePosition"
+              ],
+              "description": "The index of the change output",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "random",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "change_type"
+              ],
+              "description": "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\".",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "set by -changetype",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "includeWatching"
+              ],
+              "description": "Also select inputs which are watch only.\nOnly solvable inputs can be used. Watch-only destinations are solvable if the public key and/or output script was imported,\ne.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "true for watch-only wallets, otherwise false",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "lockUnspents"
+              ],
+              "description": "Lock selected unspent outputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "Specify a fee rate in sat/vB.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "feeRate"
+              ],
+              "description": "Specify a fee rate in BTC/kvB.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "subtractFeeFromOutputs"
+              ],
+              "description": "The integers.\nThe fee will be equally deducted from the amount of each specified output.\nThose recipients will receive less bitcoins than you enter in their corresponding amount field.\nIf no outputs are specified here, the sender pays the fee.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    "vout_index"
+                  ],
+                  "description": "The zero-based output index, before a change output is added.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            },
+            {
+              "names": [
+                "input_weights"
+              ],
+              "description": "Inputs and their corresponding weights",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "txid"
+                      ],
+                      "description": "The transaction id",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "hex"
+                    },
+                    {
+                      "names": [
+                        "vout"
+                      ],
+                      "description": "The output index",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "number"
+                    },
+                    {
+                      "names": [
+                        "weight"
+                      ],
+                      "description": "The maximum weight for this input, including the weight of the outpoint and sequence number. Note that serialized signature sizes are not guaranteed to be consistent, so the maximum DER signatures size of 73 bytes should be used when considering ECDSA signatures.Remember to convert serialized sizes to weight units when necessary.",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "number"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "names": [
+                "max_tx_weight"
+              ],
+              "description": "The maximum acceptable transaction weight.\nTransaction building will fail if this can not be satisfied.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 400000,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet default",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "solving_data"
+              ],
+              "description": "Keys and scripts needed for producing a final transaction with a dummy signature.\nUsed for fee estimation during coin selection.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "pubkeys"
+                  ],
+                  "description": "Public keys involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "pubkey"
+                      ],
+                      "description": "A public key",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "scripts"
+                  ],
+                  "description": "Scripts involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "script"
+                      ],
+                      "description": "A script",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "descriptors"
+                  ],
+                  "description": "Descriptors that provide solving data for this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "descriptor"
+                      ],
+                      "description": "A descriptor",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "iswitness"
+          ],
+          "description": "Whether the transaction hex is a serialized witness transaction.\nIf iswitness is not present, heuristic tests will be used in decoding.\nIf true, only witness deserialization will be tried.\nIf false, only non-witness deserialization will be tried.\nThis boolean should reflect whether the transaction has inputs\n(e.g. fully valid, or on-chain transactions), if known by the caller.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "depends on heuristic tests",
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The resulting raw transaction (hex-encoded string)",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "Fee in BTC the resulting transaction pays",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The position of the added change output, or -1",
+              "skip_type_check": false,
+              "key_name": "changepos",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "generate": {
+      "category": "hidden",
+      "description": "has been replaced by the -generate cli option. Refer to -help for more information.",
+      "examples": "",
+      "name": "generate",
+      "argument_names": [],
+      "arguments": [],
+      "results": []
+    },
+    "generateblock": {
+      "category": "hidden",
+      "description": "Mine a set of ordered transactions to a specified address or descriptor and return the block hash.",
+      "examples": "\nGenerate a block to myaddress, with txs rawtx and mempool_txid\n> bitcoin-cli generateblock \"myaddress\" '[\"rawtx\", \"mempool_txid\"]'\n",
+      "name": "generateblock",
+      "argument_names": [
+        "output",
+        "transactions",
+        "submit"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "output"
+          ],
+          "description": "The address or descriptor to send the newly generated bitcoin to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "transactions"
+          ],
+          "description": "An array of hex strings which are either txids or raw transactions.\nTxids must reference transactions currently in the mempool.\nAll transactions must be valid and in valid order, otherwise the block will be rejected.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "rawtx/txid"
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "submit"
+          ],
+          "description": "Whether to submit the block before the RPC call returns or to return it as hex.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "hash of generated block",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "hex of generated block, only present when submit=false",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "generatetoaddress": {
+      "category": "hidden",
+      "description": "Mine to a specified address and return the block hashes.",
+      "examples": "\nGenerate 11 blocks to myaddress\n> bitcoin-cli generatetoaddress 11 \"myaddress\"\nIf you are using the Bitcoin Core wallet, you can get a new address to send the newly generated bitcoin to with:\n> bitcoin-cli getnewaddress \n",
+      "name": "generatetoaddress",
+      "argument_names": [
+        "nblocks",
+        "address",
+        "maxtries"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "nblocks"
+          ],
+          "description": "How many blocks are generated.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The address to send the newly generated bitcoin to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "maxtries"
+          ],
+          "description": "How many iterations to try.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1000000,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "hashes of blocks generated",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "blockhash",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "generatetodescriptor": {
+      "category": "hidden",
+      "description": "Mine to a specified descriptor and return the block hashes.",
+      "examples": "\nGenerate 11 blocks to mydesc\n> bitcoin-cli generatetodescriptor 11 \"mydesc\"\n",
+      "name": "generatetodescriptor",
+      "argument_names": [
+        "num_blocks",
+        "descriptor",
+        "maxtries"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "num_blocks"
+          ],
+          "description": "How many blocks are generated.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "descriptor"
+          ],
+          "description": "The descriptor to send the newly generated bitcoin to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "maxtries"
+          ],
+          "description": "How many iterations to try.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1000000,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "hashes of blocks generated",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "blockhash",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getaddednodeinfo": {
+      "category": "network",
+      "description": "\nReturns information about the given added node, or all added nodes\n(note that onetry addnodes are not listed here)\n",
+      "examples": "> bitcoin-cli getaddednodeinfo \"192.168.0.201\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getaddednodeinfo\", \"params\": [\"192.168.0.201\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getaddednodeinfo",
+      "argument_names": [
+        "node"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "node"
+          ],
+          "description": "If provided, return information about this specific node, otherwise all nodes are returned.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "all nodes",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The node IP address or name (as provided to addnode)",
+                  "skip_type_check": false,
+                  "key_name": "addednode",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "If connected",
+                  "skip_type_check": false,
+                  "key_name": "connected",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "Only when connected = true",
+                  "skip_type_check": false,
+                  "key_name": "addresses",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The bitcoin server IP and port we're connected to",
+                          "skip_type_check": false,
+                          "key_name": "address",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "connection, inbound or outbound",
+                          "skip_type_check": false,
+                          "key_name": "connected",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getaddressesbylabel": {
+      "category": "wallet",
+      "description": "\nReturns the list of addresses assigned the specified label.\n",
+      "examples": "> bitcoin-cli getaddressesbylabel \"tabby\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getaddressesbylabel\", \"params\": [\"tabby\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getaddressesbylabel",
+      "argument_names": [
+        "label"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "label"
+          ],
+          "description": "The label.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "json object with addresses as keys",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "json object with information about address",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Purpose of address (\"send\" for sending address, \"receive\" for receiving address)",
+                  "skip_type_check": false,
+                  "key_name": "purpose",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getaddressinfo": {
+      "category": "wallet",
+      "description": "\nReturn information about the given bitcoin address.\nSome of the information will only be present if the address is in the active wallet.\n",
+      "examples": "> bitcoin-cli getaddressinfo \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getaddressinfo\", \"params\": [\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getaddressinfo",
+      "argument_names": [
+        "address"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address for which to get information.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The bitcoin address validated.",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hex-encoded output script generated by the address.",
+              "skip_type_check": false,
+              "key_name": "scriptPubKey",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the address is yours.",
+              "skip_type_check": false,
+              "key_name": "ismine",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the address is watchonly.",
+              "skip_type_check": false,
+              "key_name": "iswatchonly",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If we know how to spend coins sent to this address, ignoring the possible lack of private keys.",
+              "skip_type_check": false,
+              "key_name": "solvable",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "A descriptor for spending coins sent to this address (only when solvable).",
+              "skip_type_check": false,
+              "key_name": "desc",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The descriptor used to derive this address if this is a descriptor wallet",
+              "skip_type_check": false,
+              "key_name": "parent_desc",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "If the key is a script.",
+              "skip_type_check": false,
+              "key_name": "isscript",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the address was used for change output.",
+              "skip_type_check": false,
+              "key_name": "ischange",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the address is a witness address.",
+              "skip_type_check": false,
+              "key_name": "iswitness",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The version number of the witness program.",
+              "skip_type_check": false,
+              "key_name": "witness_version",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex value of the witness program.",
+              "skip_type_check": false,
+              "key_name": "witness_program",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The output script type. Only if isscript is true and the redeemscript is known. Possible\ntypes: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_keyhash,\nwitness_v0_scripthash, witness_unknown.",
+              "skip_type_check": false,
+              "key_name": "script",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The redeemscript for the p2sh address.",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Array of pubkeys associated with the known redeemscript (only if script is multisig).",
+              "skip_type_check": false,
+              "key_name": "pubkeys",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "pubkey",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of signatures required to spend multisig output (only if script is multisig).",
+              "skip_type_check": false,
+              "key_name": "sigsrequired",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex value of the raw public key for single-key addresses (possibly embedded in P2SH or P2WSH).",
+              "skip_type_check": false,
+              "key_name": "pubkey",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "Information about the address embedded in P2SH or P2WSH, if relevant and known.",
+              "skip_type_check": false,
+              "key_name": "embedded",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "Includes all getaddressinfo output fields for the embedded address, excluding metadata (timestamp, hdkeypath, hdseedid)\nand relation to the wallet (ismine, iswatchonly).",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "If the pubkey is compressed.",
+              "skip_type_check": false,
+              "key_name": "iscompressed",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "The creation time of the key, if available, expressed in UNIX epoch time.",
+              "skip_type_check": false,
+              "key_name": "timestamp",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The HD keypath, if the key is HD and available.",
+              "skip_type_check": false,
+              "key_name": "hdkeypath",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The Hash160 of the HD seed.",
+              "skip_type_check": false,
+              "key_name": "hdseedid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The fingerprint of the master key.",
+              "skip_type_check": false,
+              "key_name": "hdmasterfingerprint",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Array of labels associated with the address. Currently limited to one label but returned\nas an array to keep the API stable if multiple labels are enabled in the future.",
+              "skip_type_check": false,
+              "key_name": "labels",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Label name (defaults to \"\").",
+                  "skip_type_check": false,
+                  "key_name": "label name",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getaddrmaninfo": {
+      "category": "network",
+      "description": "\nProvides information about the node's address manager by returning the number of addresses in the `new` and `tried` tables and their sum for all networks.\n",
+      "examples": "> bitcoin-cli getaddrmaninfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getaddrmaninfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getaddrmaninfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "json object with network type as keys",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "the network (ipv4, ipv6, onion, i2p, cjdns, all_networks)",
+              "skip_type_check": false,
+              "key_name": "network",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to.",
+                  "skip_type_check": false,
+                  "key_name": "new",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of addresses in the tried table, which represent peers the node has successfully connected to in the past.",
+                  "skip_type_check": false,
+                  "key_name": "tried",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "total number of addresses in both new/tried tables",
+                  "skip_type_check": false,
+                  "key_name": "total",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getbalance": {
+      "category": "wallet",
+      "description": "\nReturns the total available balance.\nThe available balance is what the wallet considers currently spendable, and is\nthus affected by options which limit spendability such as -spendzeroconfchange.\n",
+      "examples": "\nThe total amount in the wallet with 0 or more confirmations\n> bitcoin-cli getbalance \n\nThe total amount in the wallet with at least 6 confirmations\n> bitcoin-cli getbalance \"*\" 6\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getbalance\", \"params\": [\"*\", 6]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getbalance",
+      "argument_names": [
+        "dummy",
+        "minconf",
+        "include_watchonly",
+        "avoid_reuse"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "dummy"
+          ],
+          "description": "Remains for backward compatibility. Must be excluded or set to \"*\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "Only include transactions confirmed at least this many times.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Also include balance in watch-only addresses (see 'importaddress')",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "avoid_reuse"
+          ],
+          "description": "(only available if avoid_reuse wallet flag is set) Do not include balance in dirty outputs; addresses are considered dirty if they have previously been used in a transaction.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "amount",
+          "optional": false,
+          "description": "The total amount in BTC received for this wallet.",
+          "skip_type_check": false,
+          "key_name": "amount",
+          "condition": ""
+        }
+      ]
+    },
+    "getbalances": {
+      "category": "wallet",
+      "description": "Returns an object with all balances in BTC.\n",
+      "examples": "> bitcoin-cli getbalances \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getbalances\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getbalances",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "balances from outputs that the wallet can sign",
+              "skip_type_check": false,
+              "key_name": "mine",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "trusted balance (outputs created by the wallet or confirmed outputs)",
+                  "skip_type_check": false,
+                  "key_name": "trusted",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "untrusted pending balance (outputs created by others that are in the mempool)",
+                  "skip_type_check": false,
+                  "key_name": "untrusted_pending",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "balance from immature coinbase outputs",
+                  "skip_type_check": false,
+                  "key_name": "immature",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": true,
+                  "description": "(only present if avoid_reuse is set) balance from coins sent to addresses that were previously spent from (potentially privacy violating)",
+                  "skip_type_check": false,
+                  "key_name": "used",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "watchonly balances (not present if wallet does not watch anything)",
+              "skip_type_check": false,
+              "key_name": "watchonly",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "trusted balance (outputs created by the wallet or confirmed outputs)",
+                  "skip_type_check": false,
+                  "key_name": "trusted",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "untrusted pending balance (outputs created by others that are in the mempool)",
+                  "skip_type_check": false,
+                  "key_name": "untrusted_pending",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "balance from immature coinbase outputs",
+                  "skip_type_check": false,
+                  "key_name": "immature",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "hash and height of the block this information was generated on",
+              "skip_type_check": false,
+              "key_name": "lastprocessedblock",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "hash",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "height of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getbestblockhash": {
+      "category": "blockchain",
+      "description": "\nReturns the hash of the best (tip) block in the most-work fully-validated chain.\n",
+      "examples": "> bitcoin-cli getbestblockhash \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getbestblockhash\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getbestblockhash",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "the block hash, hex-encoded",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getblock": {
+      "category": "blockchain",
+      "description": "\nIf verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'.\nIf verbosity is 1, returns an Object with information about block <hash>.\nIf verbosity is 2, returns an Object with information about block <hash> and information about each transaction.\nIf verbosity is 3, returns an Object with information about block <hash> and information about each transaction, including prevout information for inputs (only for unpruned blocks in the current best chain).\n",
+      "examples": "> bitcoin-cli getblock \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblock\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblock",
+      "argument_names": [
+        "blockhash",
+        "verbosity|verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The block hash",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "verbosity",
+            "verbose"
+          ],
+          "description": "0 for hex-encoded data, 1 for a JSON object, 2 for JSON object with transaction data, and 3 for JSON object with transaction data including prevout information for inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "A string that is serialized, hex-encoded data for block 'hash'",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbosity = 0"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbosity = 1",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the block hash (same as provided)",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of confirmations, or -1 if the block is not on the main chain",
+              "skip_type_check": false,
+              "key_name": "confirmations",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block size",
+              "skip_type_check": false,
+              "key_name": "size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block size excluding witness data",
+              "skip_type_check": false,
+              "key_name": "strippedsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block weight as defined in BIP 141",
+              "skip_type_check": false,
+              "key_name": "weight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block height or index",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The block version formatted in hexadecimal",
+              "skip_type_check": false,
+              "key_name": "versionHex",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The merkle root",
+              "skip_type_check": false,
+              "key_name": "merkleroot",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "The transaction ids",
+              "skip_type_check": false,
+              "key_name": "tx",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The median block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "mediantime",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The nonce",
+              "skip_type_check": false,
+              "key_name": "nonce",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "nBits: compact representation of the block difficulty target",
+              "skip_type_check": false,
+              "key_name": "bits",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The difficulty target",
+              "skip_type_check": false,
+              "key_name": "target",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The difficulty",
+              "skip_type_check": false,
+              "key_name": "difficulty",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "Expected number of hashes required to produce the chain up to this block (in hex)",
+              "skip_type_check": false,
+              "key_name": "chainwork",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of transactions in the block",
+              "skip_type_check": false,
+              "key_name": "nTx",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hash of the previous block (if available)",
+              "skip_type_check": false,
+              "key_name": "previousblockhash",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hash of the next block (if available)",
+              "skip_type_check": false,
+              "key_name": "nextblockhash",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbosity = 2",
+          "inner": [
+            {
+              "type": "elision",
+              "optional": false,
+              "description": "Same output as verbosity = 1",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "tx",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "elision",
+                      "optional": false,
+                      "description": "The transactions in the format of the getrawtransaction RPC. Different from verbosity = 1 \"tx\" result",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The transaction fee in BTC, omitted if block undo data is not available",
+                      "skip_type_check": false,
+                      "key_name": "fee",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbosity = 3",
+          "inner": [
+            {
+              "type": "elision",
+              "optional": false,
+              "description": "Same output as verbosity = 2",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "tx",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "vin",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "elision",
+                              "optional": false,
+                              "description": "The same output as verbosity = 2",
+                              "skip_type_check": false,
+                              "key_name": "",
+                              "condition": ""
+                            },
+                            {
+                              "type": "object",
+                              "optional": false,
+                              "description": "(Only if undo information is available)",
+                              "skip_type_check": false,
+                              "key_name": "prevout",
+                              "condition": "",
+                              "inner": [
+                                {
+                                  "type": "boolean",
+                                  "optional": false,
+                                  "description": "Coinbase or not",
+                                  "skip_type_check": false,
+                                  "key_name": "generated",
+                                  "condition": ""
+                                },
+                                {
+                                  "type": "number",
+                                  "optional": false,
+                                  "description": "The height of the prevout",
+                                  "skip_type_check": false,
+                                  "key_name": "height",
+                                  "condition": ""
+                                },
+                                {
+                                  "type": "amount",
+                                  "optional": false,
+                                  "description": "The value in BTC",
+                                  "skip_type_check": false,
+                                  "key_name": "value",
+                                  "condition": ""
+                                },
+                                {
+                                  "type": "object",
+                                  "optional": false,
+                                  "description": "",
+                                  "skip_type_check": false,
+                                  "key_name": "scriptPubKey",
+                                  "condition": "",
+                                  "inner": [
+                                    {
+                                      "type": "string",
+                                      "optional": false,
+                                      "description": "Disassembly of the output script",
+                                      "skip_type_check": false,
+                                      "key_name": "asm",
+                                      "condition": ""
+                                    },
+                                    {
+                                      "type": "string",
+                                      "optional": false,
+                                      "description": "Inferred descriptor for the output",
+                                      "skip_type_check": false,
+                                      "key_name": "desc",
+                                      "condition": ""
+                                    },
+                                    {
+                                      "type": "hex",
+                                      "optional": false,
+                                      "description": "The raw output script bytes, hex-encoded",
+                                      "skip_type_check": false,
+                                      "key_name": "hex",
+                                      "condition": ""
+                                    },
+                                    {
+                                      "type": "string",
+                                      "optional": true,
+                                      "description": "The Bitcoin address (only if a well-defined address exists)",
+                                      "skip_type_check": false,
+                                      "key_name": "address",
+                                      "condition": ""
+                                    },
+                                    {
+                                      "type": "string",
+                                      "optional": false,
+                                      "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                                      "skip_type_check": false,
+                                      "key_name": "type",
+                                      "condition": ""
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getblockchaininfo": {
+      "category": "blockchain",
+      "description": "Returns an object containing various state info regarding blockchain processing.\n",
+      "examples": "> bitcoin-cli getblockchaininfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockchaininfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockchaininfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "current network name (main, test, testnet4, signet, regtest)",
+              "skip_type_check": false,
+              "key_name": "chain",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the height of the most-work fully-validated chain. The genesis block has height 0",
+              "skip_type_check": false,
+              "key_name": "blocks",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the current number of headers we have validated",
+              "skip_type_check": false,
+              "key_name": "headers",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the hash of the currently best block",
+              "skip_type_check": false,
+              "key_name": "bestblockhash",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "nBits: compact representation of the block difficulty target",
+              "skip_type_check": false,
+              "key_name": "bits",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The difficulty target",
+              "skip_type_check": false,
+              "key_name": "target",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the current difficulty",
+              "skip_type_check": false,
+              "key_name": "difficulty",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The median block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "mediantime",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "estimate of verification progress [0..1]",
+              "skip_type_check": false,
+              "key_name": "verificationprogress",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "(debug information) estimate of whether this node is in Initial Block Download mode",
+              "skip_type_check": false,
+              "key_name": "initialblockdownload",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "total amount of work in active chain, in hexadecimal",
+              "skip_type_check": false,
+              "key_name": "chainwork",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the estimated size of the block and undo files on disk",
+              "skip_type_check": false,
+              "key_name": "size_on_disk",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "if the blocks are subject to pruning",
+              "skip_type_check": false,
+              "key_name": "pruned",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "height of the last block pruned, plus one (only present if pruning is enabled)",
+              "skip_type_check": false,
+              "key_name": "pruneheight",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "whether automatic pruning is enabled (only present if pruning is enabled)",
+              "skip_type_check": false,
+              "key_name": "automatic_pruning",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "the target size used by pruning (only present if automatic pruning is enabled)",
+              "skip_type_check": false,
+              "key_name": "prune_target_size",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "the block challenge (aka. block script), in hexadecimal (only present if the current network is a signet)",
+              "skip_type_check": false,
+              "key_name": "signet_challenge",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "any network and blockchain warnings (run with `-deprecatedrpc=warnings` to return the latest warning as a single string)",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "warning",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getblockcount": {
+      "category": "blockchain",
+      "description": "\nReturns the height of the most-work fully-validated chain.\nThe genesis block has height 0.\n",
+      "examples": "> bitcoin-cli getblockcount \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockcount\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockcount",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "The current block count",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getblockfilter": {
+      "category": "blockchain",
+      "description": "\nRetrieve a BIP 157 content filter for a particular block.\n",
+      "examples": "> bitcoin-cli getblockfilter \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" \"basic\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockfilter\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\", \"basic\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockfilter",
+      "argument_names": [
+        "blockhash",
+        "filtertype"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The hash of the block",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "filtertype"
+          ],
+          "description": "The type name of the filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "basic",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the hex-encoded filter data",
+              "skip_type_check": false,
+              "key_name": "filter",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the hex-encoded filter header",
+              "skip_type_check": false,
+              "key_name": "header",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getblockfrompeer": {
+      "category": "blockchain",
+      "description": "Attempt to fetch block from a given peer.\n\nWe must have the header for this block, e.g. using submitheader.\nThe block will not have any undo data which can limit the usage of the block data in a context where the undo data is needed.\nSubsequent calls for the same block may cause the response from the previous peer to be ignored.\nPeers generally ignore requests for a stale block that they never fully verified, or one that is more than a month old.\nWhen a peer does not respond with a block, we will disconnect.\nNote: The block could be re-pruned as soon as it is received.\n\nReturns an empty JSON object if the request was successfully scheduled.",
+      "examples": "> bitcoin-cli getblockfrompeer \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockfrompeer\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockfrompeer",
+      "argument_names": [
+        "blockhash",
+        "peer_id"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The block hash to try to fetch",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "peer_id"
+          ],
+          "description": "The peer to fetch it from (see getpeerinfo for peer IDs)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getblockhash": {
+      "category": "blockchain",
+      "description": "\nReturns hash of block in best-block-chain at height provided.\n",
+      "examples": "> bitcoin-cli getblockhash 1000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockhash\", \"params\": [1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockhash",
+      "argument_names": [
+        "height"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "height"
+          ],
+          "description": "The height index",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "The block hash",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getblockheader": {
+      "category": "blockchain",
+      "description": "\nIf verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.\nIf verbose is true, returns an Object with information about blockheader <hash>.\n",
+      "examples": "> bitcoin-cli getblockheader \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockheader\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockheader",
+      "argument_names": [
+        "blockhash",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The block hash",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "true for a json object, false for the hex-encoded data",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = true",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the block hash (same as provided)",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of confirmations, or -1 if the block is not on the main chain",
+              "skip_type_check": false,
+              "key_name": "confirmations",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block height or index",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The block version formatted in hexadecimal",
+              "skip_type_check": false,
+              "key_name": "versionHex",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The merkle root",
+              "skip_type_check": false,
+              "key_name": "merkleroot",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The median block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "mediantime",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The nonce",
+              "skip_type_check": false,
+              "key_name": "nonce",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "nBits: compact representation of the block difficulty target",
+              "skip_type_check": false,
+              "key_name": "bits",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The difficulty target",
+              "skip_type_check": false,
+              "key_name": "target",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The difficulty",
+              "skip_type_check": false,
+              "key_name": "difficulty",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "Expected number of hashes required to produce the current chain",
+              "skip_type_check": false,
+              "key_name": "chainwork",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of transactions in the block",
+              "skip_type_check": false,
+              "key_name": "nTx",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hash of the previous block (if available)",
+              "skip_type_check": false,
+              "key_name": "previousblockhash",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hash of the next block (if available)",
+              "skip_type_check": false,
+              "key_name": "nextblockhash",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "A string that is serialized, hex-encoded data for block 'hash'",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose=false"
+        }
+      ]
+    },
+    "getblockstats": {
+      "category": "blockchain",
+      "description": "\nCompute per block statistics for a given window. All amounts are in satoshis.\nIt won't work for some heights with pruning.\n",
+      "examples": "> bitcoin-cli getblockstats '\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"' '[\"minfeerate\",\"avgfeerate\"]'\n> bitcoin-cli getblockstats 1000 '[\"minfeerate\",\"avgfeerate\"]'\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockstats\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\", [\"minfeerate\",\"avgfeerate\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblockstats\", \"params\": [1000, [\"minfeerate\",\"avgfeerate\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblockstats",
+      "argument_names": [
+        "hash_or_height",
+        "stats"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hash_or_height"
+          ],
+          "description": "The block hash or height of the target block",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [
+            "",
+            "string or numeric"
+          ],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "stats"
+          ],
+          "description": "Values to plot (see result below)",
+          "oneline_description": "stats",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "all values",
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "height"
+              ],
+              "description": "Selected statistic",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "time"
+              ],
+              "description": "Selected statistic",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Average fee in the block",
+              "skip_type_check": false,
+              "key_name": "avgfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Average feerate (in satoshis per virtual byte)",
+              "skip_type_check": false,
+              "key_name": "avgfeerate",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Average transaction size",
+              "skip_type_check": false,
+              "key_name": "avgtxsize",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The block hash (to check for potential reorgs)",
+              "skip_type_check": false,
+              "key_name": "blockhash",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per virtual byte)",
+              "skip_type_check": false,
+              "key_name": "feerate_percentiles",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The 10th percentile feerate",
+                  "skip_type_check": false,
+                  "key_name": "10th_percentile_feerate",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The 25th percentile feerate",
+                  "skip_type_check": false,
+                  "key_name": "25th_percentile_feerate",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The 50th percentile feerate",
+                  "skip_type_check": false,
+                  "key_name": "50th_percentile_feerate",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The 75th percentile feerate",
+                  "skip_type_check": false,
+                  "key_name": "75th_percentile_feerate",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The 90th percentile feerate",
+                  "skip_type_check": false,
+                  "key_name": "90th_percentile_feerate",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The height of the block",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of inputs (excluding coinbase)",
+              "skip_type_check": false,
+              "key_name": "ins",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Maximum fee in the block",
+              "skip_type_check": false,
+              "key_name": "maxfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Maximum feerate (in satoshis per virtual byte)",
+              "skip_type_check": false,
+              "key_name": "maxfeerate",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Maximum transaction size",
+              "skip_type_check": false,
+              "key_name": "maxtxsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Truncated median fee in the block",
+              "skip_type_check": false,
+              "key_name": "medianfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The block median time past",
+              "skip_type_check": false,
+              "key_name": "mediantime",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Truncated median transaction size",
+              "skip_type_check": false,
+              "key_name": "mediantxsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Minimum fee in the block",
+              "skip_type_check": false,
+              "key_name": "minfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Minimum feerate (in satoshis per virtual byte)",
+              "skip_type_check": false,
+              "key_name": "minfeerate",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Minimum transaction size",
+              "skip_type_check": false,
+              "key_name": "mintxsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of outputs",
+              "skip_type_check": false,
+              "key_name": "outs",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The block subsidy",
+              "skip_type_check": false,
+              "key_name": "subsidy",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Total size of all segwit transactions",
+              "skip_type_check": false,
+              "key_name": "swtotal_size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Total weight of all segwit transactions",
+              "skip_type_check": false,
+              "key_name": "swtotal_weight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of segwit transactions",
+              "skip_type_check": false,
+              "key_name": "swtxs",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The block time",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])",
+              "skip_type_check": false,
+              "key_name": "total_out",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Total size of all non-coinbase transactions",
+              "skip_type_check": false,
+              "key_name": "total_size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Total weight of all non-coinbase transactions",
+              "skip_type_check": false,
+              "key_name": "total_weight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The fee total",
+              "skip_type_check": false,
+              "key_name": "totalfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of transactions (including coinbase)",
+              "skip_type_check": false,
+              "key_name": "txs",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The increase/decrease in the number of unspent outputs (not discounting op_return and similar)",
+              "skip_type_check": false,
+              "key_name": "utxo_increase",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The increase/decrease in size for the utxo index (not discounting op_return and similar)",
+              "skip_type_check": false,
+              "key_name": "utxo_size_inc",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The increase/decrease in the number of unspent outputs, not counting unspendables",
+              "skip_type_check": false,
+              "key_name": "utxo_increase_actual",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The increase/decrease in size for the utxo index, not counting unspendables",
+              "skip_type_check": false,
+              "key_name": "utxo_size_inc_actual",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getblocktemplate": {
+      "category": "mining",
+      "description": "\nIf the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'.\nIt returns data needed to construct a block to work on.\nFor full specification, see BIPs 22, 23, 9, and 145:\n    https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki\n    https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki\n    https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki#getblocktemplate_changes\n    https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki\n",
+      "examples": "> bitcoin-cli getblocktemplate '{\"rules\": [\"segwit\"]}'\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getblocktemplate\", \"params\": [{\"rules\": [\"segwit\"]}]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getblocktemplate",
+      "argument_names": [
+        "template_request"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "template_request"
+          ],
+          "description": "Format of the template",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "mode"
+              ],
+              "description": "This must be set to \"template\", \"proposal\" (see BIP 23), or omitted",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "capabilities"
+              ],
+              "description": "A list of strings",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    "str"
+                  ],
+                  "description": "client side supported feature, 'longpoll', 'coinbasevalue', 'proposal', 'serverlist', 'workid'",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "names": [
+                "rules"
+              ],
+              "description": "A list of strings",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": true,
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    "segwit"
+                  ],
+                  "description": "(literal) indicates client side segwit support",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "str"
+                  ],
+                  "description": "other client side supported softfork deployment",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "names": [
+                "longpollid"
+              ],
+              "description": "delay processing request until the result would vary significantly from the \"longpollid\" of a prior template",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "data"
+              ],
+              "description": "proposed block data to check, encoded in hexadecimal; valid only for mode=\"proposal\"",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "If the proposal was accepted with mode=='proposal'"
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "description": "According to BIP22",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "If the proposal was not accepted with mode=='proposal'"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "Otherwise",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The preferred block version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "specific block rules that are to be enforced",
+              "skip_type_check": false,
+              "key_name": "rules",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "name of a rule the client must understand to some extent; see BIP 9 for format",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "set of pending, supported versionbit (BIP 9) softfork deployments",
+              "skip_type_check": false,
+              "key_name": "vbavailable",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "identifies the bit number as indicating acceptance and readiness for the named softfork rule",
+                  "skip_type_check": false,
+                  "key_name": "rulename",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "capabilities",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "A supported feature, for example 'proposal'",
+                  "skip_type_check": false,
+                  "key_name": "value",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "bit mask of versionbits the server requires set in submissions",
+              "skip_type_check": false,
+              "key_name": "vbrequired",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The hash of current highest block",
+              "skip_type_check": false,
+              "key_name": "previousblockhash",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "contents of non-coinbase transactions that should be included in the next block",
+              "skip_type_check": false,
+              "key_name": "transactions",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "transaction data encoded in hexadecimal (byte-for-byte)",
+                      "skip_type_check": false,
+                      "key_name": "data",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "transaction hash excluding witness data, shown in byte-reversed hex",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "transaction hash including witness data, shown in byte-reversed hex",
+                      "skip_type_check": false,
+                      "key_name": "hash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "array of numbers",
+                      "skip_type_check": false,
+                      "key_name": "depends",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "transactions before this one (by 1-based index in 'transactions' list) that must be present in the final block if this one is",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "difference in value between transaction inputs and outputs (in satoshis); for coinbase transactions, this is a negative Number of the total collected block fees (ie, not including the block subsidy); if key is not present, fee is unknown and clients MUST NOT assume there isn't one",
+                      "skip_type_check": false,
+                      "key_name": "fee",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "total SigOps cost, as counted for purposes of block limits; if key is not present, sigop cost is unknown and clients MUST NOT assume it is zero",
+                      "skip_type_check": false,
+                      "key_name": "sigops",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "total transaction weight, as counted for purposes of block limits",
+                      "skip_type_check": false,
+                      "key_name": "weight",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "data that should be included in the coinbase's scriptSig content",
+              "skip_type_check": false,
+              "key_name": "coinbaseaux",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "values must be in the coinbase (keys may be ignored)",
+                  "skip_type_check": false,
+                  "key_name": "key",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "maximum allowable input to coinbase transaction, including the generation award and transaction fees (in satoshis)",
+              "skip_type_check": false,
+              "key_name": "coinbasevalue",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "an id to include with a request to longpoll on an update to this template",
+              "skip_type_check": false,
+              "key_name": "longpollid",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The hash target",
+              "skip_type_check": false,
+              "key_name": "target",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The minimum timestamp appropriate for the next block time, expressed in UNIX epoch time. Adjusted for the proposed BIP94 timewarp rule.",
+              "skip_type_check": false,
+              "key_name": "mintime",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "list of ways the block template may be changed",
+              "skip_type_check": false,
+              "key_name": "mutable",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "A way the block template may be changed, e.g. 'time', 'transactions', 'prevblock'",
+                  "skip_type_check": false,
+                  "key_name": "value",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "A range of valid nonces",
+              "skip_type_check": false,
+              "key_name": "noncerange",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "limit of sigops in blocks",
+              "skip_type_check": false,
+              "key_name": "sigoplimit",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "limit of block size",
+              "skip_type_check": false,
+              "key_name": "sizelimit",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "limit of block weight",
+              "skip_type_check": false,
+              "key_name": "weightlimit",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "current timestamp in UNIX epoch time. Adjusted for the proposed BIP94 timewarp rule.",
+              "skip_type_check": false,
+              "key_name": "curtime",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "compressed target of next block",
+              "skip_type_check": false,
+              "key_name": "bits",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The height of the next block",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "Only on signet",
+              "skip_type_check": false,
+              "key_name": "signet_challenge",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "a valid witness commitment for the unmodified block template",
+              "skip_type_check": false,
+              "key_name": "default_witness_commitment",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getchainstates": {
+      "category": "blockchain",
+      "description": "\nReturn information about chainstates.\n",
+      "examples": "> bitcoin-cli getchainstates \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getchainstates\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getchainstates",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of headers seen so far",
+              "skip_type_check": false,
+              "key_name": "headers",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "list of the chainstates ordered by work, with the most-work (active) chainstate last",
+              "skip_type_check": false,
+              "key_name": "chainstates",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "number of blocks in this chainstate",
+                      "skip_type_check": false,
+                      "key_name": "blocks",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "blockhash of the tip",
+                      "skip_type_check": false,
+                      "key_name": "bestblockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "nBits: compact representation of the block difficulty target",
+                      "skip_type_check": false,
+                      "key_name": "bits",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The difficulty target",
+                      "skip_type_check": false,
+                      "key_name": "target",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "difficulty of the tip",
+                      "skip_type_check": false,
+                      "key_name": "difficulty",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "progress towards the network tip",
+                      "skip_type_check": false,
+                      "key_name": "verificationprogress",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "the base block of the snapshot this chainstate is based on, if any",
+                      "skip_type_check": false,
+                      "key_name": "snapshot_blockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "size of the coinsdb cache",
+                      "skip_type_check": false,
+                      "key_name": "coins_db_cache_bytes",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "size of the coinstip cache",
+                      "skip_type_check": false,
+                      "key_name": "coins_tip_cache_bytes",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "whether the chainstate is fully validated. True if all blocks in the chainstate were validated, false if the chain is based on a snapshot and the snapshot has not yet been validated.",
+                      "skip_type_check": false,
+                      "key_name": "validated",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getchaintips": {
+      "category": "blockchain",
+      "description": "Return information about all known tips in the block tree, including the main chain as well as orphaned branches.\n",
+      "examples": "> bitcoin-cli getchaintips \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getchaintips\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getchaintips",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "height of the chain tip",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "block hash of the tip",
+                  "skip_type_check": false,
+                  "key_name": "hash",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "zero for main chain, otherwise length of branch connecting the tip to the main chain",
+                  "skip_type_check": false,
+                  "key_name": "branchlen",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "status of the chain, \"active\" for the main chain\nPossible values for status:\n1.  \"invalid\"               This branch contains at least one invalid block\n2.  \"headers-only\"          Not all blocks for this branch are available, but the headers are valid\n3.  \"valid-headers\"         All blocks are available for this branch, but they were never fully validated\n4.  \"valid-fork\"            This branch is not part of the active chain, but is fully validated\n5.  \"active\"                This is the tip of the active main chain, which is certainly valid",
+                  "skip_type_check": false,
+                  "key_name": "status",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getchaintxstats": {
+      "category": "blockchain",
+      "description": "\nCompute statistics about the total number and rate of transactions in the chain.\n",
+      "examples": "> bitcoin-cli getchaintxstats \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getchaintxstats\", \"params\": [2016]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getchaintxstats",
+      "argument_names": [
+        "nblocks",
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "nblocks"
+          ],
+          "description": "Size of the window in number of blocks",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "one month",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The hash of the block that ends the window.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "chain tip",
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The timestamp for the final block in the window, expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The total number of transactions in the chain up to that point, if known. It may be unknown when using assumeutxo.",
+              "skip_type_check": false,
+              "key_name": "txcount",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of the final block in the window",
+              "skip_type_check": false,
+              "key_name": "window_final_block_hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The height of the final block in the window.",
+              "skip_type_check": false,
+              "key_name": "window_final_block_height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Size of the window in number of blocks",
+              "skip_type_check": false,
+              "key_name": "window_block_count",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The elapsed time in the window in seconds. Only returned if \"window_block_count\" is > 0",
+              "skip_type_check": false,
+              "key_name": "window_interval",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of transactions in the window. Only returned if \"window_block_count\" is > 0 and if txcount exists for the start and end of the window.",
+              "skip_type_check": false,
+              "key_name": "window_tx_count",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The average rate of transactions per second in the window. Only returned if \"window_interval\" is > 0 and if window_tx_count exists.",
+              "skip_type_check": false,
+              "key_name": "txrate",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getconnectioncount": {
+      "category": "network",
+      "description": "\nReturns the number of connections to other nodes.\n",
+      "examples": "> bitcoin-cli getconnectioncount \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getconnectioncount\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getconnectioncount",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "The connection count",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getdeploymentinfo": {
+      "category": "blockchain",
+      "description": "Returns an object containing various state info regarding deployments of consensus changes.",
+      "examples": "> bitcoin-cli getdeploymentinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getdeploymentinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getdeploymentinfo",
+      "argument_names": [
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The block hash at which to query deployment state",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "hash of current chain tip",
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "requested block hash (or tip)",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "requested block height (or tip)",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "deployments",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "name of the deployment",
+                  "skip_type_check": false,
+                  "key_name": "xxxx",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "one of \"buried\", \"bip9\"",
+                      "skip_type_check": false,
+                      "key_name": "type",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "height of the first block which the rules are or will be enforced (only for \"buried\" type, or \"bip9\" type with \"active\" status)",
+                      "skip_type_check": false,
+                      "key_name": "height",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "true if the rules are enforced for the mempool and the next block",
+                      "skip_type_check": false,
+                      "key_name": "active",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "status of bip9 softforks (only for \"bip9\" type)",
+                      "skip_type_check": false,
+                      "key_name": "bip9",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "number",
+                          "optional": true,
+                          "description": "the bit (0-28) in the block version field used to signal this softfork (only for \"started\" and \"locked_in\" status)",
+                          "skip_type_check": false,
+                          "key_name": "bit",
+                          "condition": ""
+                        },
+                        {
+                          "type": "timestamp",
+                          "optional": false,
+                          "description": "the minimum median time past of a block at which the bit gains its meaning",
+                          "skip_type_check": false,
+                          "key_name": "start_time",
+                          "condition": ""
+                        },
+                        {
+                          "type": "timestamp",
+                          "optional": false,
+                          "description": "the median time past of a block at which the deployment is considered failed if not yet locked in",
+                          "skip_type_check": false,
+                          "key_name": "timeout",
+                          "condition": ""
+                        },
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "minimum height of blocks for which the rules may be enforced",
+                          "skip_type_check": false,
+                          "key_name": "min_activation_height",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "status of deployment at specified block (one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\")",
+                          "skip_type_check": false,
+                          "key_name": "status",
+                          "condition": ""
+                        },
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "height of the first block to which the status applies",
+                          "skip_type_check": false,
+                          "key_name": "since",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "status of deployment at the next block",
+                          "skip_type_check": false,
+                          "key_name": "status_next",
+                          "condition": ""
+                        },
+                        {
+                          "type": "object",
+                          "optional": true,
+                          "description": "numeric statistics about signalling for a softfork (only for \"started\" and \"locked_in\" status)",
+                          "skip_type_check": false,
+                          "key_name": "statistics",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "the length in blocks of the signalling period",
+                              "skip_type_check": false,
+                              "key_name": "period",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": true,
+                              "description": "the number of blocks with the version bit set required to activate the feature (only for \"started\" status)",
+                              "skip_type_check": false,
+                              "key_name": "threshold",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "the number of blocks elapsed since the beginning of the current period",
+                              "skip_type_check": false,
+                              "key_name": "elapsed",
+                              "condition": ""
+                            },
+                            {
+                              "type": "number",
+                              "optional": false,
+                              "description": "the number of blocks with the version bit set in the current period",
+                              "skip_type_check": false,
+                              "key_name": "count",
+                              "condition": ""
+                            },
+                            {
+                              "type": "boolean",
+                              "optional": true,
+                              "description": "returns false if there are not enough blocks left in this period to pass activation threshold (only for \"started\" status)",
+                              "skip_type_check": false,
+                              "key_name": "possible",
+                              "condition": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "string",
+                          "optional": true,
+                          "description": "indicates blocks that signalled with a # and blocks that did not with a -",
+                          "skip_type_check": false,
+                          "key_name": "signalling",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getdescriptoractivity": {
+      "category": "blockchain",
+      "description": "\nGet spend and receive activity associated with a set of descriptors for a set of blocks. This command pairs well with the `relevant_blocks` output of `scanblocks()`.\nThis call may take several minutes. If you encounter timeouts, try specifying no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli getdescriptoractivity '[\"000000000000000000001347062c12fded7c528943c8ce133987e2e2f5a840ee\"]' '[\"addr(bc1qzl6nsgqzu89a66l50cvwapnkw5shh23zarqkw9)\"]'\n",
+      "name": "getdescriptoractivity",
+      "argument_names": [
+        "blockhashes",
+        "scanobjects",
+        "include_mempool"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhashes"
+          ],
+          "description": "The list of blockhashes to examine for activity. Order doesn't matter. Must be along main chain or an error is thrown.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "blockhash"
+              ],
+              "description": "A valid blockhash",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "scanobjects"
+          ],
+          "description": "Array of scan objects. Required for \"start\" action\nEvery scan object is either a string descriptor or an object:",
+          "oneline_description": "[scanobjects,...]",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "descriptor"
+              ],
+              "description": "An output descriptor",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "An object with output descriptor and metadata",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "An output descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "The range of HD chain indexes to explore (either end or [begin,end])",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": 1000,
+                  "hidden": false,
+                  "type": "range"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "include_mempool"
+          ],
+          "description": "Whether to include unconfirmed activity",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "events",
+              "skip_type_check": true,
+              "key_name": "activity",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "always 'spend'",
+                      "skip_type_check": false,
+                      "key_name": "type",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The total amount in BTC of the spent output",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The blockhash this spend appears in (omitted if unconfirmed)",
+                      "skip_type_check": false,
+                      "key_name": "blockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "Height of the spend (omitted if unconfirmed)",
+                      "skip_type_check": false,
+                      "key_name": "height",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The txid of the spending transaction",
+                      "skip_type_check": false,
+                      "key_name": "spend_txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The vout of the spend",
+                      "skip_type_check": false,
+                      "key_name": "spend_vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The txid of the prevout",
+                      "skip_type_check": false,
+                      "key_name": "prevout_txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The vout of the prevout",
+                      "skip_type_check": false,
+                      "key_name": "prevout_vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "prevout_spk",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the output script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Inferred descriptor for the output",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw output script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": true,
+                          "description": "The Bitcoin address (only if a well-defined address exists)",
+                          "skip_type_check": false,
+                          "key_name": "address",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "always 'receive'",
+                      "skip_type_check": false,
+                      "key_name": "type",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The total amount in BTC of the new output",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The block that this receive is in (omitted if unconfirmed)",
+                      "skip_type_check": false,
+                      "key_name": "blockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The height of the receive (omitted if unconfirmed)",
+                      "skip_type_check": false,
+                      "key_name": "height",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The txid of the receiving transaction",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The vout of the receiving output",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "output_spk",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the output script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Inferred descriptor for the output",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw output script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": true,
+                          "description": "The Bitcoin address (only if a well-defined address exists)",
+                          "skip_type_check": false,
+                          "key_name": "address",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getdescriptorinfo": {
+      "category": "util",
+      "description": "\nAnalyses a descriptor.\n",
+      "examples": "Analyse a descriptor\n> bitcoin-cli getdescriptorinfo \"wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798)\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getdescriptorinfo\", \"params\": [\"wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798)\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getdescriptorinfo",
+      "argument_names": [
+        "descriptor"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "descriptor"
+          ],
+          "description": "The descriptor.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The descriptor in canonical form, without private keys. For a multipath descriptor, only the first will be returned.",
+              "skip_type_check": false,
+              "key_name": "descriptor",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "All descriptors produced by expanding multipath derivation elements. Only if the provided descriptor specifies multipath derivation elements.",
+              "skip_type_check": false,
+              "key_name": "multipath_expansion",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The checksum for the input descriptor",
+              "skip_type_check": false,
+              "key_name": "checksum",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether the descriptor is ranged",
+              "skip_type_check": false,
+              "key_name": "isrange",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether the descriptor is solvable",
+              "skip_type_check": false,
+              "key_name": "issolvable",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether the input descriptor contained at least one private key",
+              "skip_type_check": false,
+              "key_name": "hasprivatekeys",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getdifficulty": {
+      "category": "blockchain",
+      "description": "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n",
+      "examples": "> bitcoin-cli getdifficulty \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getdifficulty\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getdifficulty",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "the proof-of-work difficulty as a multiple of the minimum difficulty.",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "gethdkeys": {
+      "category": "wallet",
+      "description": "\nList all BIP 32 HD keys in the wallet and which descriptors use them.\n",
+      "examples": "> bitcoin-cli gethdkeys \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gethdkeys\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli -named gethdkeys active_only=true private=true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gethdkeys\", \"params\": {\"active_only\":\"true\",\"private\":\"true\"}}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "gethdkeys",
+      "argument_names": [
+        "active_only",
+        "private",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "active_only"
+              ],
+              "description": "Show the keys for only active descriptors",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "private"
+              ],
+              "description": "Show private keys",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The extended public key",
+                  "skip_type_check": false,
+                  "key_name": "xpub",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether the wallet has the private key for this xpub",
+                  "skip_type_check": false,
+                  "key_name": "has_private",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "The extended private key if \"private\" is true",
+                  "skip_type_check": false,
+                  "key_name": "xprv",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "Array of descriptor objects that use this HD key",
+                  "skip_type_check": false,
+                  "key_name": "descriptors",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Descriptor string representation",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        },
+                        {
+                          "type": "boolean",
+                          "optional": false,
+                          "description": "Whether this descriptor is currently used to generate new addresses",
+                          "skip_type_check": false,
+                          "key_name": "active",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getindexinfo": {
+      "category": "util",
+      "description": "\nReturns the status of one or all available indices currently running in the node.\n",
+      "examples": "> bitcoin-cli getindexinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getindexinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli getindexinfo txindex\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getindexinfo\", \"params\": [txindex]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getindexinfo",
+      "argument_names": [
+        "index_name"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "index_name"
+          ],
+          "description": "Filter results for an index with a specific name.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "The name of the index",
+              "skip_type_check": false,
+              "key_name": "name",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether the index is synced or not",
+                  "skip_type_check": false,
+                  "key_name": "synced",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The block height to which the index is synced",
+                  "skip_type_check": false,
+                  "key_name": "best_block_height",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getmemoryinfo": {
+      "category": "control",
+      "description": "Returns an object containing information about memory usage.\n",
+      "examples": "> bitcoin-cli getmemoryinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmemoryinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmemoryinfo",
+      "argument_names": [
+        "mode"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "mode"
+          ],
+          "description": "determines what kind of information is returned.\n  - \"stats\" returns general statistics about memory usage in the daemon.\n  - \"mallocinfo\" returns an XML string describing low-level heap state (only available if compiled with glibc).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "stats",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "mode \"stats\"",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "Information about locked memory manager",
+              "skip_type_check": false,
+              "key_name": "locked",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Number of bytes used",
+                  "skip_type_check": false,
+                  "key_name": "used",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Number of bytes available in current arenas",
+                  "skip_type_check": false,
+                  "key_name": "free",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Total number of bytes managed",
+                  "skip_type_check": false,
+                  "key_name": "total",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Amount of bytes that succeeded locking. If this number is smaller than total, locking pages failed at some point and key data could be swapped to disk.",
+                  "skip_type_check": false,
+                  "key_name": "locked",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Number allocated chunks",
+                  "skip_type_check": false,
+                  "key_name": "chunks_used",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Number unused chunks",
+                  "skip_type_check": false,
+                  "key_name": "chunks_free",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "description": "\"<malloc version=\"1\">...\"",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "mode \"mallocinfo\""
+        }
+      ]
+    },
+    "getmempoolancestors": {
+      "category": "blockchain",
+      "description": "\nIf txid is in the mempool, returns all in-mempool ancestors.\n",
+      "examples": "> bitcoin-cli getmempoolancestors \"mytxid\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmempoolancestors\", \"params\": [\"mytxid\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmempoolancestors",
+      "argument_names": [
+        "txid",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id (must be in mempool)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "True for a json object, false for array of transaction ids",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = false",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id of an in-mempool ancestor transaction",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = true",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "transactionid",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "transaction weight as defined in BIP 141.",
+                  "skip_type_check": false,
+                  "key_name": "weight",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT",
+                  "skip_type_check": false,
+                  "key_name": "time",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "block height when transaction entered pool",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool descendant transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool descendants (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool ancestor transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool ancestors (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorsize",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of serialized transaction, including witness data",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "fees",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "base",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "modified",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool ancestors (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "ancestor",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool descendants (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "descendant",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions used as inputs for this transaction",
+                  "skip_type_check": false,
+                  "key_name": "depends",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "parent transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions spending outputs from this transaction",
+                  "skip_type_check": false,
+                  "key_name": "spentby",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "child transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n",
+                  "skip_type_check": false,
+                  "key_name": "bip125-replaceable",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction is currently unbroadcast (initial broadcast not yet acknowledged by any peers)",
+                  "skip_type_check": false,
+                  "key_name": "unbroadcast",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getmempooldescendants": {
+      "category": "blockchain",
+      "description": "\nIf txid is in the mempool, returns all in-mempool descendants.\n",
+      "examples": "> bitcoin-cli getmempooldescendants \"mytxid\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmempooldescendants\", \"params\": [\"mytxid\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmempooldescendants",
+      "argument_names": [
+        "txid",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id (must be in mempool)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "True for a json object, false for array of transaction ids",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = false",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id of an in-mempool descendant transaction",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = true",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "transactionid",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "transaction weight as defined in BIP 141.",
+                  "skip_type_check": false,
+                  "key_name": "weight",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT",
+                  "skip_type_check": false,
+                  "key_name": "time",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "block height when transaction entered pool",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool descendant transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool descendants (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool ancestor transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool ancestors (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorsize",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of serialized transaction, including witness data",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "fees",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "base",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "modified",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool ancestors (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "ancestor",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool descendants (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "descendant",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions used as inputs for this transaction",
+                  "skip_type_check": false,
+                  "key_name": "depends",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "parent transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions spending outputs from this transaction",
+                  "skip_type_check": false,
+                  "key_name": "spentby",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "child transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n",
+                  "skip_type_check": false,
+                  "key_name": "bip125-replaceable",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction is currently unbroadcast (initial broadcast not yet acknowledged by any peers)",
+                  "skip_type_check": false,
+                  "key_name": "unbroadcast",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getmempoolentry": {
+      "category": "blockchain",
+      "description": "\nReturns mempool data for given transaction\n",
+      "examples": "> bitcoin-cli getmempoolentry \"mytxid\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmempoolentry\", \"params\": [\"mytxid\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmempoolentry",
+      "argument_names": [
+        "txid"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id (must be in mempool)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+              "skip_type_check": false,
+              "key_name": "vsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "transaction weight as defined in BIP 141.",
+              "skip_type_check": false,
+              "key_name": "weight",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "block height when transaction entered pool",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "number of in-mempool descendant transactions (including this one)",
+              "skip_type_check": false,
+              "key_name": "descendantcount",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "virtual transaction size of in-mempool descendants (including this one)",
+              "skip_type_check": false,
+              "key_name": "descendantsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "number of in-mempool ancestor transactions (including this one)",
+              "skip_type_check": false,
+              "key_name": "ancestorcount",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "virtual transaction size of in-mempool ancestors (including this one)",
+              "skip_type_check": false,
+              "key_name": "ancestorsize",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "hash of serialized transaction, including witness data",
+              "skip_type_check": false,
+              "key_name": "wtxid",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "fees",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "transaction fee, denominated in BTC",
+                  "skip_type_check": false,
+                  "key_name": "base",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "transaction fee with fee deltas used for mining priority, denominated in BTC",
+                  "skip_type_check": false,
+                  "key_name": "modified",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "transaction fees of in-mempool ancestors (including this one) with fee deltas used for mining priority, denominated in BTC",
+                  "skip_type_check": false,
+                  "key_name": "ancestor",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "transaction fees of in-mempool descendants (including this one) with fee deltas used for mining priority, denominated in BTC",
+                  "skip_type_check": false,
+                  "key_name": "descendant",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "unconfirmed transactions used as inputs for this transaction",
+              "skip_type_check": false,
+              "key_name": "depends",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "parent transaction id",
+                  "skip_type_check": false,
+                  "key_name": "transactionid",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "unconfirmed transactions spending outputs from this transaction",
+              "skip_type_check": false,
+              "key_name": "spentby",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "child transaction id",
+                  "skip_type_check": false,
+                  "key_name": "transactionid",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n",
+              "skip_type_check": false,
+              "key_name": "bip125-replaceable",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether this transaction is currently unbroadcast (initial broadcast not yet acknowledged by any peers)",
+              "skip_type_check": false,
+              "key_name": "unbroadcast",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getmempoolinfo": {
+      "category": "blockchain",
+      "description": "Returns details on the active state of the TX memory pool.",
+      "examples": "> bitcoin-cli getmempoolinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmempoolinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmempoolinfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "True if the initial load attempt of the persisted mempool finished",
+              "skip_type_check": false,
+              "key_name": "loaded",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Current tx count",
+              "skip_type_check": false,
+              "key_name": "size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted",
+              "skip_type_check": false,
+              "key_name": "bytes",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Total memory usage for the mempool",
+              "skip_type_check": false,
+              "key_name": "usage",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "Total fees for the mempool in BTC, ignoring modified fees through prioritisetransaction",
+              "skip_type_check": false,
+              "key_name": "total_fee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Maximum memory usage for the mempool",
+              "skip_type_check": false,
+              "key_name": "maxmempool",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "Minimum fee rate in BTC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee",
+              "skip_type_check": false,
+              "key_name": "mempoolminfee",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "Current minimum relay fee for transactions",
+              "skip_type_check": false,
+              "key_name": "minrelaytxfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "minimum fee rate increment for mempool limiting or replacement in BTC/kvB",
+              "skip_type_check": false,
+              "key_name": "incrementalrelayfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Current number of transactions that haven't passed initial broadcast yet",
+              "skip_type_check": false,
+              "key_name": "unbroadcastcount",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)",
+              "skip_type_check": false,
+              "key_name": "fullrbf",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getmininginfo": {
+      "category": "mining",
+      "description": "\nReturns a json object containing mining-related information.",
+      "examples": "> bitcoin-cli getmininginfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getmininginfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getmininginfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The current block",
+              "skip_type_check": false,
+              "key_name": "blocks",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The block weight (including reserved weight for block header, txs count and coinbase tx) of the last assembled block (only present if a block was ever assembled)",
+              "skip_type_check": false,
+              "key_name": "currentblockweight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of block transactions (excluding coinbase) of the last assembled block (only present if a block was ever assembled)",
+              "skip_type_check": false,
+              "key_name": "currentblocktx",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The current nBits, compact representation of the block difficulty target",
+              "skip_type_check": false,
+              "key_name": "bits",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The current difficulty",
+              "skip_type_check": false,
+              "key_name": "difficulty",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The current target",
+              "skip_type_check": false,
+              "key_name": "target",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The network hashes per second",
+              "skip_type_check": false,
+              "key_name": "networkhashps",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The size of the mempool",
+              "skip_type_check": false,
+              "key_name": "pooledtx",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "current network name (main, test, testnet4, signet, regtest)",
+              "skip_type_check": false,
+              "key_name": "chain",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The block challenge (aka. block script), in hexadecimal (only present if the current network is a signet)",
+              "skip_type_check": false,
+              "key_name": "signet_challenge",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "The next block",
+              "skip_type_check": false,
+              "key_name": "next",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The next height",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The next target nBits",
+                  "skip_type_check": false,
+                  "key_name": "bits",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The next difficulty",
+                  "skip_type_check": false,
+                  "key_name": "difficulty",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The next target",
+                  "skip_type_check": false,
+                  "key_name": "target",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "any network and blockchain warnings (run with `-deprecatedrpc=warnings` to return the latest warning as a single string)",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "warning",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getnettotals": {
+      "category": "network",
+      "description": "Returns information about network traffic, including bytes in, bytes out,\nand current system time.",
+      "examples": "> bitcoin-cli getnettotals \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnettotals\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getnettotals",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Total bytes received",
+              "skip_type_check": false,
+              "key_name": "totalbytesrecv",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Total bytes sent",
+              "skip_type_check": false,
+              "key_name": "totalbytessent",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "Current system UNIX epoch time in milliseconds",
+              "skip_type_check": false,
+              "key_name": "timemillis",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "uploadtarget",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Length of the measuring timeframe in seconds",
+                  "skip_type_check": false,
+                  "key_name": "timeframe",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Target in bytes",
+                  "skip_type_check": false,
+                  "key_name": "target",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "True if target is reached",
+                  "skip_type_check": false,
+                  "key_name": "target_reached",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "True if serving historical blocks",
+                  "skip_type_check": false,
+                  "key_name": "serve_historical_blocks",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Bytes left in current time cycle",
+                  "skip_type_check": false,
+                  "key_name": "bytes_left_in_cycle",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Seconds left in current time cycle",
+                  "skip_type_check": false,
+                  "key_name": "time_left_in_cycle",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getnetworkhashps": {
+      "category": "mining",
+      "description": "\nReturns the estimated network hashes per second based on the last n blocks.\nPass in [blocks] to override # of blocks, -1 specifies since last difficulty change.\nPass in [height] to estimate the network speed at the time when a certain block was found.\n",
+      "examples": "> bitcoin-cli getnetworkhashps \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnetworkhashps\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getnetworkhashps",
+      "argument_names": [
+        "nblocks",
+        "height"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "nblocks"
+          ],
+          "description": "The number of previous blocks to calculate estimate from, or -1 for blocks since last difficulty change.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 120,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "height"
+          ],
+          "description": "To estimate at the time of the given height.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": -1,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "Hashes per second estimated",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getnetworkinfo": {
+      "category": "network",
+      "description": "Returns an object containing various state info regarding P2P networking.\n",
+      "examples": "> bitcoin-cli getnetworkinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnetworkinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getnetworkinfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the server version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the server subversion string",
+              "skip_type_check": false,
+              "key_name": "subversion",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the protocol version",
+              "skip_type_check": false,
+              "key_name": "protocolversion",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the services we offer to the network",
+              "skip_type_check": false,
+              "key_name": "localservices",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "the services we offer to the network, in human-readable form",
+              "skip_type_check": false,
+              "key_name": "localservicesnames",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "the service name",
+                  "skip_type_check": false,
+                  "key_name": "SERVICE_NAME",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "true if transaction relay is requested from peers",
+              "skip_type_check": false,
+              "key_name": "localrelay",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the time offset",
+              "skip_type_check": false,
+              "key_name": "timeoffset",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the total number of connections",
+              "skip_type_check": false,
+              "key_name": "connections",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of inbound connections",
+              "skip_type_check": false,
+              "key_name": "connections_in",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of outbound connections",
+              "skip_type_check": false,
+              "key_name": "connections_out",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "whether p2p networking is enabled",
+              "skip_type_check": false,
+              "key_name": "networkactive",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "information per network",
+              "skip_type_check": false,
+              "key_name": "networks",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "network (ipv4, ipv6, onion, i2p, cjdns)",
+                      "skip_type_check": false,
+                      "key_name": "name",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "is the network limited using -onlynet?",
+                      "skip_type_check": false,
+                      "key_name": "limited",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "is the network reachable?",
+                      "skip_type_check": false,
+                      "key_name": "reachable",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "(\"host:port\") the proxy that is used for this network, or empty if none",
+                      "skip_type_check": false,
+                      "key_name": "proxy",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "Whether randomized credentials are used",
+                      "skip_type_check": false,
+                      "key_name": "proxy_randomize_credentials",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "minimum relay fee rate for transactions in BTC/kvB",
+              "skip_type_check": false,
+              "key_name": "relayfee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "minimum fee rate increment for mempool limiting or replacement in BTC/kvB",
+              "skip_type_check": false,
+              "key_name": "incrementalfee",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "list of local addresses",
+              "skip_type_check": false,
+              "key_name": "localaddresses",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "network address",
+                      "skip_type_check": false,
+                      "key_name": "address",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "network port",
+                      "skip_type_check": false,
+                      "key_name": "port",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "relative score",
+                      "skip_type_check": false,
+                      "key_name": "score",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "any network and blockchain warnings (run with `-deprecatedrpc=warnings` to return the latest warning as a single string)",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "warning",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getnewaddress": {
+      "category": "wallet",
+      "description": "\nReturns a new Bitcoin address for receiving payments.\nIf 'label' is specified, it is added to the address book \nso payments received with the address will be associated with 'label'.\n",
+      "examples": "> bitcoin-cli getnewaddress \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnewaddress\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getnewaddress",
+      "argument_names": [
+        "label",
+        "address_type"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "label"
+          ],
+          "description": "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "address_type"
+          ],
+          "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "set by -addresstype",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The new bitcoin address",
+          "skip_type_check": false,
+          "key_name": "address",
+          "condition": ""
+        }
+      ]
+    },
+    "getnodeaddresses": {
+      "category": "network",
+      "description": "Return known addresses, after filtering for quality and recency.\nThese can potentially be used to find new peers in the network.\nThe total number of addresses known to the node may be higher.",
+      "examples": "> bitcoin-cli getnodeaddresses 8\n> bitcoin-cli getnodeaddresses 4 \"i2p\"\n> bitcoin-cli -named getnodeaddresses network=onion count=12\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnodeaddresses\", \"params\": [8]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getnodeaddresses\", \"params\": [4, \"i2p\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getnodeaddresses",
+      "argument_names": [
+        "count",
+        "network"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "count"
+          ],
+          "description": "The maximum number of addresses to return. Specify 0 to return all known addresses.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "network"
+          ],
+          "description": "Return only addresses of the specified network. Can be one of: ipv4, ipv6, onion, i2p, cjdns.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "all networks",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time when the node was last seen",
+                  "skip_type_check": false,
+                  "key_name": "time",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The services offered by the node",
+                  "skip_type_check": false,
+                  "key_name": "services",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The address of the node",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The port number of the node",
+                  "skip_type_check": false,
+                  "key_name": "port",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The network (ipv4, ipv6, onion, i2p, cjdns) the node connected through",
+                  "skip_type_check": false,
+                  "key_name": "network",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getorphantxs": {
+      "category": "hidden",
+      "description": "\nShows transactions in the tx orphanage.\n\nEXPERIMENTAL warning: this call may be changed in future releases.\n",
+      "examples": "> bitcoin-cli getorphantxs 2\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getorphantxs\", \"params\": [2]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getorphantxs",
+      "argument_names": [
+        "verbosity"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "verbosity"
+          ],
+          "description": "0 for an array of txids (may contain duplicates), 1 for an array of objects with tx details, and 2 for details from (1) and tx hex",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = 0",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction hash in hex",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = 1",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction witness hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The serialized transaction size in bytes",
+                  "skip_type_check": false,
+                  "key_name": "bytes",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The transaction weight as defined in BIP 141.",
+                  "skip_type_check": false,
+                  "key_name": "weight",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The entry time into the orphanage expressed in UNIX epoch time",
+                  "skip_type_check": false,
+                  "key_name": "entry",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The orphan expiration time expressed in UNIX epoch time",
+                  "skip_type_check": false,
+                  "key_name": "expiration",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "from",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Peer ID",
+                      "skip_type_check": false,
+                      "key_name": "peer_id",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = 2",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction witness hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The serialized transaction size in bytes",
+                  "skip_type_check": false,
+                  "key_name": "bytes",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The transaction weight as defined in BIP 141.",
+                  "skip_type_check": false,
+                  "key_name": "weight",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The entry time into the orphanage expressed in UNIX epoch time",
+                  "skip_type_check": false,
+                  "key_name": "entry",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The orphan expiration time expressed in UNIX epoch time",
+                  "skip_type_check": false,
+                  "key_name": "expiration",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "from",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Peer ID",
+                      "skip_type_check": false,
+                      "key_name": "peer_id",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The serialized, hex-encoded transaction data",
+                  "skip_type_check": false,
+                  "key_name": "hex",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getpeerinfo": {
+      "category": "network",
+      "description": "Returns data about each connected network peer as a json array of objects.",
+      "examples": "> bitcoin-cli getpeerinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getpeerinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getpeerinfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "Peer index",
+                  "skip_type_check": false,
+                  "key_name": "id",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "(host:port) The IP address and port of the peer",
+                  "skip_type_check": false,
+                  "key_name": "addr",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "(ip:port) Bind address of the connection to the peer",
+                  "skip_type_check": false,
+                  "key_name": "addrbind",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "(ip:port) Local address as reported by the peer",
+                  "skip_type_check": false,
+                  "key_name": "addrlocal",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Network (ipv4, ipv6, onion, i2p, cjdns, not_publicly_routable)",
+                  "skip_type_check": false,
+                  "key_name": "network",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying\npeer selection (only displayed if the -asmap config option is set)",
+                  "skip_type_check": false,
+                  "key_name": "mapped_as",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The services offered",
+                  "skip_type_check": false,
+                  "key_name": "services",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "the services offered, in human-readable form",
+                  "skip_type_check": false,
+                  "key_name": "servicesnames",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "the service name if it is recognised",
+                      "skip_type_check": false,
+                      "key_name": "SERVICE_NAME",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether we relay transactions to this peer",
+                  "skip_type_check": false,
+                  "key_name": "relaytxes",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time of the last send",
+                  "skip_type_check": false,
+                  "key_name": "lastsend",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time of the last receive",
+                  "skip_type_check": false,
+                  "key_name": "lastrecv",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time of the last valid transaction received from this peer",
+                  "skip_type_check": false,
+                  "key_name": "last_transaction",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time of the last block received from this peer",
+                  "skip_type_check": false,
+                  "key_name": "last_block",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The total bytes sent",
+                  "skip_type_check": false,
+                  "key_name": "bytessent",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The total bytes received",
+                  "skip_type_check": false,
+                  "key_name": "bytesrecv",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time of the connection",
+                  "skip_type_check": false,
+                  "key_name": "conntime",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The time offset in seconds",
+                  "skip_type_check": false,
+                  "key_name": "timeoffset",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The last ping time in milliseconds (ms), if any",
+                  "skip_type_check": false,
+                  "key_name": "pingtime",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The minimum observed ping time in milliseconds (ms), if any",
+                  "skip_type_check": false,
+                  "key_name": "minping",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The duration in milliseconds (ms) of an outstanding ping (if non-zero)",
+                  "skip_type_check": false,
+                  "key_name": "pingwait",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The peer version, such as 70001",
+                  "skip_type_check": false,
+                  "key_name": "version",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The string version",
+                  "skip_type_check": false,
+                  "key_name": "subver",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Inbound (true) or Outbound (false)",
+                  "skip_type_check": false,
+                  "key_name": "inbound",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether we selected peer as (compact blocks) high-bandwidth peer",
+                  "skip_type_check": false,
+                  "key_name": "bip152_hb_to",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether peer selected us as (compact blocks) high-bandwidth peer",
+                  "skip_type_check": false,
+                  "key_name": "bip152_hb_from",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The starting height (block) of the peer",
+                  "skip_type_check": false,
+                  "key_name": "startingheight",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The current height of header pre-synchronization with this peer, or -1 if no low-work sync is in progress",
+                  "skip_type_check": false,
+                  "key_name": "presynced_headers",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The last header we have in common with this peer",
+                  "skip_type_check": false,
+                  "key_name": "synced_headers",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The last block we have in common with this peer",
+                  "skip_type_check": false,
+                  "key_name": "synced_blocks",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "inflight",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The heights of blocks we're currently asking from this peer",
+                      "skip_type_check": false,
+                      "key_name": "n",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether we participate in address relay with this peer",
+                  "skip_type_check": false,
+                  "key_name": "addr_relay_enabled",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The total number of addresses processed, excluding those dropped due to rate limiting",
+                  "skip_type_check": false,
+                  "key_name": "addr_processed",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The total number of addresses dropped due to rate limiting",
+                  "skip_type_check": false,
+                  "key_name": "addr_rate_limited",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "Any special permissions that have been granted to this peer",
+                  "skip_type_check": false,
+                  "key_name": "permissions",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "bloomfilter (allow requesting BIP37 filtered blocks and transactions),\nnoban (do not ban for misbehavior; implies download),\nforcerelay (relay transactions that are already in the mempool; implies relay),\nrelay (relay even in -blocksonly mode, and unlimited transaction announcements),\nmempool (allow requesting BIP35 mempool contents),\ndownload (allow getheaders during IBD, no disconnect after maxuploadtarget limit),\naddr (responses to GETADDR avoid hitting the cache and contain random records with the most up-to-date info).\n",
+                      "skip_type_check": false,
+                      "key_name": "permission_type",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The minimum fee rate for transactions this peer accepts",
+                  "skip_type_check": false,
+                  "key_name": "minfeefilter",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "bytessent_per_msg",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The total bytes sent aggregated by message type\nWhen a message type is not listed in this json object, the bytes sent are 0.\nOnly known message types can appear as keys in the object.",
+                      "skip_type_check": false,
+                      "key_name": "msg",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "bytesrecv_per_msg",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The total bytes received aggregated by message type\nWhen a message type is not listed in this json object, the bytes received are 0.\nOnly known message types can appear as keys in the object and all bytes received\nof unknown message types are listed under '*other*'.",
+                      "skip_type_check": false,
+                      "key_name": "msg",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Type of connection: \noutbound-full-relay (default automatic connections),\nblock-relay-only (does not relay transactions or addresses),\ninbound (initiated by the peer),\nmanual (added via addnode RPC or -addnode/-connect configuration options),\naddr-fetch (short-lived automatic connection for soliciting addresses),\nfeeler (short-lived automatic connection for testing addresses).\nPlease note this output is unlikely to be stable in upcoming releases as we iterate to\nbest capture connection behaviors.",
+                  "skip_type_check": false,
+                  "key_name": "connection_type",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Type of transport protocol: \ndetecting (peer could be v1 or v2),\nv1 (plaintext transport protocol),\nv2 (BIP324 encrypted transport protocol).\n",
+                  "skip_type_check": false,
+                  "key_name": "transport_protocol_type",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The session ID for this connection, or \"\" if there is none (\"v2\" transport protocol only).\n",
+                  "skip_type_check": false,
+                  "key_name": "session_id",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getprioritisedtransactions": {
+      "category": "mining",
+      "description": "Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.",
+      "examples": "> bitcoin-cli getprioritisedtransactions \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getprioritisedtransactions\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getprioritisedtransactions",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "prioritisation keyed by txid",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "<transactionid>",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "transaction fee delta in satoshis",
+                  "skip_type_check": false,
+                  "key_name": "fee_delta",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "whether this transaction is currently in mempool",
+                  "skip_type_check": false,
+                  "key_name": "in_mempool",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "modified fee in satoshis. Only returned if in_mempool=true",
+                  "skip_type_check": false,
+                  "key_name": "modified_fee",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getrawaddrman": {
+      "category": "hidden",
+      "description": "EXPERIMENTAL warning: this call may be changed in future releases.\n\nReturns information on all address manager entries for the new and tried tables.\n",
+      "examples": "> bitcoin-cli getrawaddrman \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getrawaddrman\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getrawaddrman",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "buckets with addresses in the address manager table ( new, tried )",
+              "skip_type_check": false,
+              "key_name": "table",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "the location in the address manager table (<bucket>/<position>)",
+                  "skip_type_check": false,
+                  "key_name": "bucket/position",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The address of the node",
+                      "skip_type_check": false,
+                      "key_name": "address",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying peer selection (only displayed if the -asmap config option is set)",
+                      "skip_type_check": false,
+                      "key_name": "mapped_as",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The port number of the node",
+                      "skip_type_check": false,
+                      "key_name": "port",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The network (ipv4, ipv6, onion, i2p, cjdns) of the address",
+                      "skip_type_check": false,
+                      "key_name": "network",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The services offered by the node",
+                      "skip_type_check": false,
+                      "key_name": "services",
+                      "condition": ""
+                    },
+                    {
+                      "type": "timestamp",
+                      "optional": false,
+                      "description": "The UNIX epoch time when the node was last seen",
+                      "skip_type_check": false,
+                      "key_name": "time",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The address that relayed the address to us",
+                      "skip_type_check": false,
+                      "key_name": "source",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The network (ipv4, ipv6, onion, i2p, cjdns) of the source address",
+                      "skip_type_check": false,
+                      "key_name": "source_network",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "Mapped AS (Autonomous System) number at the end of the BGP route to the source, used for diversifying peer selection (only displayed if the -asmap config option is set)",
+                      "skip_type_check": false,
+                      "key_name": "source_mapped_as",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getrawchangeaddress": {
+      "category": "wallet",
+      "description": "\nReturns a new Bitcoin address, for receiving change.\nThis is for use with raw transactions, NOT normal use.\n",
+      "examples": "> bitcoin-cli getrawchangeaddress \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getrawchangeaddress\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getrawchangeaddress",
+      "argument_names": [
+        "address_type"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address_type"
+          ],
+          "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "set by -changetype",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The address",
+          "skip_type_check": false,
+          "key_name": "address",
+          "condition": ""
+        }
+      ]
+    },
+    "getrawmempool": {
+      "category": "blockchain",
+      "description": "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n\nHint: use getmempoolentry to fetch a specific transaction from the mempool.\n",
+      "examples": "> bitcoin-cli getrawmempool true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getrawmempool\", \"params\": [true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getrawmempool",
+      "argument_names": [
+        "verbose",
+        "mempool_sequence"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "True for a json object, false for array of transaction ids",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "mempool_sequence"
+          ],
+          "description": "If verbose=false, returns a json object with transaction list and mempool sequence number attached.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = false",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = true",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "transactionid",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "transaction weight as defined in BIP 141.",
+                  "skip_type_check": false,
+                  "key_name": "weight",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT",
+                  "skip_type_check": false,
+                  "key_name": "time",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "block height when transaction entered pool",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool descendant transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool descendants (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "descendantsize",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "number of in-mempool ancestor transactions (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "virtual transaction size of in-mempool ancestors (including this one)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorsize",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of serialized transaction, including witness data",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "fees",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "base",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "modified",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool ancestors (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "ancestor",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fees of in-mempool descendants (including this one) with fee deltas used for mining priority, denominated in BTC",
+                      "skip_type_check": false,
+                      "key_name": "descendant",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions used as inputs for this transaction",
+                  "skip_type_check": false,
+                  "key_name": "depends",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "parent transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "unconfirmed transactions spending outputs from this transaction",
+                  "skip_type_check": false,
+                  "key_name": "spentby",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "child transaction id",
+                      "skip_type_check": false,
+                      "key_name": "transactionid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n",
+                  "skip_type_check": false,
+                  "key_name": "bip125-replaceable",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this transaction is currently unbroadcast (initial broadcast not yet acknowledged by any peers)",
+                  "skip_type_check": false,
+                  "key_name": "unbroadcast",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbose = false and mempool_sequence = true",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "txids",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The mempool sequence value.",
+              "skip_type_check": false,
+              "key_name": "mempool_sequence",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "getrawtransaction": {
+      "category": "rawtransactions",
+      "description": "By default, this call only returns a transaction if it is in the mempool. If -txindex is enabled\nand no blockhash argument is passed, it will return the transaction if it is in the mempool or any block.\nIf a blockhash argument is passed, it will return the transaction if\nthe specified block is available and the transaction is in that block.\n\nHint: Use gettransaction for wallet transactions.\n\nIf verbosity is 0 or omitted, returns the serialized transaction as a hex-encoded string.\nIf verbosity is 1, returns a JSON Object with information about the transaction.\nIf verbosity is 2, returns a JSON Object with information about the transaction, including fee and prevout information.",
+      "examples": "> bitcoin-cli getrawtransaction \"mytxid\"\n> bitcoin-cli getrawtransaction \"mytxid\" 1\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"mytxid\", 1]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli getrawtransaction \"mytxid\" 0 \"myblockhash\"\n> bitcoin-cli getrawtransaction \"mytxid\" 1 \"myblockhash\"\n> bitcoin-cli getrawtransaction \"mytxid\" 2 \"myblockhash\"\n",
+      "name": "getrawtransaction",
+      "argument_names": [
+        "txid",
+        "verbosity|verbose",
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "verbosity",
+            "verbose"
+          ],
+          "description": "0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "The block in which to look for the transaction",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The serialized transaction as a hex-encoded string for 'txid'",
+          "skip_type_check": false,
+          "key_name": "data",
+          "condition": "if verbosity is not set or set to 0"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "if verbosity is set to 1",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "Whether specified block is in the active chain or not (only present with explicit \"blockhash\" argument)",
+              "skip_type_check": false,
+              "key_name": "in_active_chain",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "the block hash",
+              "skip_type_check": false,
+              "key_name": "blockhash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The confirmations",
+              "skip_type_check": false,
+              "key_name": "confirmations",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "The block time expressed in UNIX epoch time",
+              "skip_type_check": false,
+              "key_name": "blocktime",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "Same as \"blocktime\"",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The serialized, hex-encoded data for 'txid'",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id (same as provided)",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction hash (differs from txid for witness transactions)",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The serialized transaction size",
+              "skip_type_check": false,
+              "key_name": "size",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The virtual transaction size (differs from size for witness transactions)",
+              "skip_type_check": false,
+              "key_name": "vsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The transaction's weight (between vsize*4-3 and vsize*4)",
+              "skip_type_check": false,
+              "key_name": "weight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The version",
+              "skip_type_check": false,
+              "key_name": "version",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The lock time",
+              "skip_type_check": false,
+              "key_name": "locktime",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "vin",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The coinbase value (only if coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "coinbase",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The transaction id (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The output number (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "The script (if not coinbase transaction)",
+                      "skip_type_check": false,
+                      "key_name": "scriptSig",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the signature script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw signature script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "txinwitness",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "hex-encoded witness data (if any)",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The script sequence number",
+                      "skip_type_check": false,
+                      "key_name": "sequence",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "vout",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The value in BTC",
+                      "skip_type_check": false,
+                      "key_name": "value",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "index",
+                      "skip_type_check": false,
+                      "key_name": "n",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "scriptPubKey",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Disassembly of the output script",
+                          "skip_type_check": false,
+                          "key_name": "asm",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "Inferred descriptor for the output",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        },
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The raw output script bytes, hex-encoded",
+                          "skip_type_check": false,
+                          "key_name": "hex",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": true,
+                          "description": "The Bitcoin address (only if a well-defined address exists)",
+                          "skip_type_check": false,
+                          "key_name": "address",
+                          "condition": ""
+                        },
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                          "skip_type_check": false,
+                          "key_name": "type",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "for verbosity = 2",
+          "inner": [
+            {
+              "type": "elision",
+              "optional": false,
+              "description": "Same output as verbosity = 1",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "transaction fee in BTC, omitted if block undo data is not available",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "vin",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "utxo being spent",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "elision",
+                      "optional": false,
+                      "description": "Same output as verbosity = 1",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "The previous output, omitted if block undo data is not available",
+                      "skip_type_check": false,
+                      "key_name": "prevout",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "boolean",
+                          "optional": false,
+                          "description": "Coinbase or not",
+                          "skip_type_check": false,
+                          "key_name": "generated",
+                          "condition": ""
+                        },
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "The height of the prevout",
+                          "skip_type_check": false,
+                          "key_name": "height",
+                          "condition": ""
+                        },
+                        {
+                          "type": "amount",
+                          "optional": false,
+                          "description": "The value in BTC",
+                          "skip_type_check": false,
+                          "key_name": "value",
+                          "condition": ""
+                        },
+                        {
+                          "type": "object",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "scriptPubKey",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "Disassembly of the output script",
+                              "skip_type_check": false,
+                              "key_name": "asm",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "Inferred descriptor for the output",
+                              "skip_type_check": false,
+                              "key_name": "desc",
+                              "condition": ""
+                            },
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "The raw output script bytes, hex-encoded",
+                              "skip_type_check": false,
+                              "key_name": "hex",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": true,
+                              "description": "The Bitcoin address (only if a well-defined address exists)",
+                              "skip_type_check": false,
+                              "key_name": "address",
+                              "condition": ""
+                            },
+                            {
+                              "type": "string",
+                              "optional": false,
+                              "description": "The type (one of: nonstandard, anchor, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)",
+                              "skip_type_check": false,
+                              "key_name": "type",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getreceivedbyaddress": {
+      "category": "wallet",
+      "description": "\nReturns the total amount received by the given address in transactions with at least minconf confirmations.\n",
+      "examples": "\nThe amount from transactions with at least 1 confirmation\n> bitcoin-cli getreceivedbyaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"\n\nThe amount including unconfirmed transactions, zero confirmations\n> bitcoin-cli getreceivedbyaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 0\n\nThe amount with at least 6 confirmations\n> bitcoin-cli getreceivedbyaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 6\n\nThe amount with at least 6 confirmations including immature coinbase outputs\n> bitcoin-cli getreceivedbyaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 6 true\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getreceivedbyaddress\", \"params\": [\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\", 6]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getreceivedbyaddress",
+      "argument_names": [
+        "address",
+        "minconf",
+        "include_immature_coinbase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address for transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "Only include transactions confirmed at least this many times.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_immature_coinbase"
+          ],
+          "description": "Include immature coinbase transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "amount",
+          "optional": false,
+          "description": "The total amount in BTC received at this address.",
+          "skip_type_check": false,
+          "key_name": "amount",
+          "condition": ""
+        }
+      ]
+    },
+    "getreceivedbylabel": {
+      "category": "wallet",
+      "description": "\nReturns the total amount received by addresses with <label> in transactions with at least [minconf] confirmations.\n",
+      "examples": "\nAmount received by the default label with at least 1 confirmation\n> bitcoin-cli getreceivedbylabel \"\"\n\nAmount received at the tabby label including unconfirmed amounts with zero confirmations\n> bitcoin-cli getreceivedbylabel \"tabby\" 0\n\nThe amount with at least 6 confirmations\n> bitcoin-cli getreceivedbylabel \"tabby\" 6\n\nThe amount with at least 6 confirmations including immature coinbase outputs\n> bitcoin-cli getreceivedbylabel \"tabby\" 6 true\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getreceivedbylabel\", \"params\": [\"tabby\", 6, true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getreceivedbylabel",
+      "argument_names": [
+        "label",
+        "minconf",
+        "include_immature_coinbase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "label"
+          ],
+          "description": "The selected label, may be the default label using \"\".",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "Only include transactions confirmed at least this many times.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_immature_coinbase"
+          ],
+          "description": "Include immature coinbase transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "amount",
+          "optional": false,
+          "description": "The total amount in BTC received for this label.",
+          "skip_type_check": false,
+          "key_name": "amount",
+          "condition": ""
+        }
+      ]
+    },
+    "getrpcinfo": {
+      "category": "control",
+      "description": "\nReturns details of the RPC server.\n",
+      "examples": "> bitcoin-cli getrpcinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getrpcinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getrpcinfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "All active commands",
+              "skip_type_check": false,
+              "key_name": "active_commands",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "Information about an active command",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The name of the RPC command",
+                      "skip_type_check": false,
+                      "key_name": "method",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The running time in microseconds",
+                      "skip_type_check": false,
+                      "key_name": "duration",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The complete file path to the debug log",
+              "skip_type_check": false,
+              "key_name": "logpath",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "gettransaction": {
+      "category": "wallet",
+      "description": "\nGet detailed information about in-wallet transaction <txid>\n",
+      "examples": "> bitcoin-cli gettransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"\n> bitcoin-cli gettransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" true\n> bitcoin-cli gettransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" false true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettransaction\", \"params\": [\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "gettransaction",
+      "argument_names": [
+        "txid",
+        "include_watchonly",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Whether to include watch-only addresses in balance calculation and details[]",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "Whether to include a `decoded` field containing the decoded transaction (equivalent to RPC decoderawtransaction)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The amount in BTC",
+              "skip_type_check": false,
+              "key_name": "amount",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": true,
+              "description": "The amount of the fee in BTC. This is negative and only available for the\n'send' category of transactions.",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of confirmations for the transaction. Negative confirmations means the\ntransaction conflicted that many blocks ago.",
+              "skip_type_check": false,
+              "key_name": "confirmations",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "Only present if the transaction's only input is a coinbase one.",
+              "skip_type_check": false,
+              "key_name": "generated",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "Whether we consider the transaction to be trusted and safe to spend from.\nOnly present when the transaction has 0 confirmations (or negative confirmations, if conflicted).",
+              "skip_type_check": false,
+              "key_name": "trusted",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The block hash containing the transaction.",
+              "skip_type_check": false,
+              "key_name": "blockhash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The block height containing the transaction.",
+              "skip_type_check": false,
+              "key_name": "blockheight",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The index of the transaction in the block that includes it.",
+              "skip_type_check": false,
+              "key_name": "blockindex",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "The block time expressed in UNIX epoch time.",
+              "skip_type_check": false,
+              "key_name": "blocktime",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of serialized transaction, including witness data.",
+              "skip_type_check": false,
+              "key_name": "wtxid",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Confirmed transactions that have been detected by the wallet to conflict with this transaction.",
+              "skip_type_check": false,
+              "key_name": "walletconflicts",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id.",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "Only if 'category' is 'send'. The txid if this tx was replaced.",
+              "skip_type_check": false,
+              "key_name": "replaced_by_txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "Only if 'category' is 'send'. The txid if this tx replaces another.",
+              "skip_type_check": false,
+              "key_name": "replaces_txid",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Transactions in the mempool that directly conflict with either this transaction or an ancestor transaction",
+              "skip_type_check": false,
+              "key_name": "mempoolconflicts",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id.",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "If a comment to is associated with the transaction.",
+              "skip_type_check": false,
+              "key_name": "to",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The transaction time expressed in UNIX epoch time.",
+              "skip_type_check": false,
+              "key_name": "time",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": false,
+              "description": "The time received expressed in UNIX epoch time.",
+              "skip_type_check": false,
+              "key_name": "timereceived",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "If a comment is associated with the transaction, only present if not empty.",
+              "skip_type_check": false,
+              "key_name": "comment",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "(\"yes|no|unknown\") Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability.\nMay be unknown for unconfirmed transactions not in the mempool because their unconfirmed ancestors are unknown.",
+              "skip_type_check": false,
+              "key_name": "bip125-replaceable",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.",
+              "skip_type_check": false,
+              "key_name": "parent_descs",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The descriptor string.",
+                  "skip_type_check": false,
+                  "key_name": "desc",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "details",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "boolean",
+                      "optional": true,
+                      "description": "Only returns true if imported addresses were involved in transaction.",
+                      "skip_type_check": false,
+                      "key_name": "involvesWatchonly",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "The bitcoin address involved in the transaction.",
+                      "skip_type_check": false,
+                      "key_name": "address",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The transaction category.\n\"send\"                  Transactions sent.\n\"receive\"               Non-coinbase transactions received.\n\"generate\"              Coinbase transactions received with more than 100 confirmations.\n\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n\"orphan\"                Orphaned coinbase transactions received.",
+                      "skip_type_check": false,
+                      "key_name": "category",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The amount in BTC",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "A comment for the address/transaction, if any",
+                      "skip_type_check": false,
+                      "key_name": "label",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "the vout value",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": true,
+                      "description": "The amount of the fee in BTC. This is negative and only available for the \n'send' category of transactions.",
+                      "skip_type_check": false,
+                      "key_name": "fee",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "'true' if the transaction has been abandoned (inputs are respendable).",
+                      "skip_type_check": false,
+                      "key_name": "abandoned",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.",
+                      "skip_type_check": false,
+                      "key_name": "parent_descs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The descriptor string.",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "Raw data for transaction",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "The decoded transaction (only present when `verbose` is passed)",
+              "skip_type_check": false,
+              "key_name": "decoded",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "Equivalent to the RPC decoderawtransaction method, or the RPC getrawtransaction method when `verbose` is passed.",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "hash and height of the block this information was generated on",
+              "skip_type_check": false,
+              "key_name": "lastprocessedblock",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "hash",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "height of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "gettxout": {
+      "category": "blockchain",
+      "description": "\nReturns details about an unspent transaction output.\n",
+      "examples": "\nGet unspent transactions\n> bitcoin-cli listunspent \n\nView the details\n> bitcoin-cli gettxout \"txid\" 1\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxout\", \"params\": [\"txid\", 1]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "gettxout",
+      "argument_names": [
+        "txid",
+        "n",
+        "include_mempool"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "n"
+          ],
+          "description": "vout number",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_mempool"
+          ],
+          "description": "Whether to include the mempool. Note that an unspent output that is spent in the mempool won't appear.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "If the UTXO was not found"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "Otherwise",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of the block at the tip of the chain",
+              "skip_type_check": false,
+              "key_name": "bestblock",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of confirmations",
+              "skip_type_check": false,
+              "key_name": "confirmations",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The transaction value in BTC",
+              "skip_type_check": false,
+              "key_name": "value",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "scriptPubKey",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Disassembly of the output script",
+                  "skip_type_check": false,
+                  "key_name": "asm",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "Inferred descriptor for the output",
+                  "skip_type_check": false,
+                  "key_name": "desc",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The raw output script bytes, hex-encoded",
+                  "skip_type_check": false,
+                  "key_name": "hex",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The type, eg pubkeyhash",
+                  "skip_type_check": false,
+                  "key_name": "type",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "The Bitcoin address (only if a well-defined address exists)",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Coinbase or not",
+              "skip_type_check": false,
+              "key_name": "coinbase",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "gettxoutproof": {
+      "category": "blockchain",
+      "description": "\nReturns a hex-encoded proof that \"txid\" was included in a block.\n\nNOTE: By default this function only works sometimes. This is when there is an\nunspent output in the utxo for this transaction. To make it always work,\nyou need to maintain a transaction index, using the -txindex command line option or\nspecify the block in which the transaction is included manually (by blockhash).\n",
+      "examples": "",
+      "name": "gettxoutproof",
+      "argument_names": [
+        "txids",
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txids"
+          ],
+          "description": "The txids to filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "txid"
+              ],
+              "description": "A transaction hash",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "If specified, looks for txid in the block with this hash",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "A string that is a serialized, hex-encoded data for the proof.",
+          "skip_type_check": false,
+          "key_name": "data",
+          "condition": ""
+        }
+      ]
+    },
+    "gettxoutsetinfo": {
+      "category": "blockchain",
+      "description": "\nReturns statistics about the unspent transaction output set.\nNote this call may take some time if you are not using coinstatsindex.\n",
+      "examples": "> bitcoin-cli gettxoutsetinfo \n> bitcoin-cli gettxoutsetinfo \"none\"\n> bitcoin-cli gettxoutsetinfo \"none\" 1000\n> bitcoin-cli gettxoutsetinfo \"none\" '\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"'\n> bitcoin-cli -named gettxoutsetinfo hash_type='muhash' use_index='false'\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxoutsetinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxoutsetinfo\", \"params\": [\"none\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxoutsetinfo\", \"params\": [\"none\", 1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxoutsetinfo\", \"params\": [\"none\", \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "gettxoutsetinfo",
+      "argument_names": [
+        "hash_type",
+        "hash_or_height",
+        "use_index"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hash_type"
+          ],
+          "description": "Which UTXO set hash should be calculated. Options: 'hash_serialized_3' (the legacy algorithm), 'muhash', 'none'.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "hash_serialized_3",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "hash_or_height"
+          ],
+          "description": "The block hash or height of the target height (only available with coinstatsindex).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [
+            "",
+            "string or numeric"
+          ],
+          "required": false,
+          "default_hint": "the current best block",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "use_index"
+          ],
+          "description": "Use coinstatsindex, if available.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block height (index) of the returned statistics",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of the block at which these statistics are calculated",
+              "skip_type_check": false,
+              "key_name": "bestblock",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of unspent transaction outputs",
+              "skip_type_check": false,
+              "key_name": "txouts",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Database-independent, meaningless metric indicating the UTXO set size",
+              "skip_type_check": false,
+              "key_name": "bogosize",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The serialized hash (only present if 'hash_serialized_3' hash_type is chosen)",
+              "skip_type_check": false,
+              "key_name": "hash_serialized_3",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The serialized hash (only present if 'muhash' hash_type is chosen)",
+              "skip_type_check": false,
+              "key_name": "muhash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The number of transactions with unspent outputs (not available when coinstatsindex is used)",
+              "skip_type_check": false,
+              "key_name": "transactions",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The estimated size of the chainstate on disk (not available when coinstatsindex is used)",
+              "skip_type_check": false,
+              "key_name": "disk_size",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The total amount of coins in the UTXO set",
+              "skip_type_check": false,
+              "key_name": "total_amount",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": true,
+              "description": "The total amount of coins permanently excluded from the UTXO set (only available if coinstatsindex is used)",
+              "skip_type_check": false,
+              "key_name": "total_unspendable_amount",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": true,
+              "description": "Info on amounts in the block at this block height (only available if coinstatsindex is used)",
+              "skip_type_check": false,
+              "key_name": "block_info",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "Total amount of all prevouts spent in this block",
+                  "skip_type_check": false,
+                  "key_name": "prevout_spent",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "Coinbase subsidy amount of this block",
+                  "skip_type_check": false,
+                  "key_name": "coinbase",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "Total amount of new outputs created by this block",
+                  "skip_type_check": false,
+                  "key_name": "new_outputs_ex_coinbase",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "Total amount of unspendable outputs created in this block",
+                  "skip_type_check": false,
+                  "key_name": "unspendable",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "Detailed view of the unspendable categories",
+                  "skip_type_check": false,
+                  "key_name": "unspendables",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The unspendable amount of the Genesis block subsidy",
+                      "skip_type_check": false,
+                      "key_name": "genesis_block",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "Transactions overridden by duplicates (no longer possible with BIP30)",
+                      "skip_type_check": false,
+                      "key_name": "bip30",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "Amounts sent to scripts that are unspendable (for example OP_RETURN outputs)",
+                      "skip_type_check": false,
+                      "key_name": "scripts",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "Fee rewards that miners did not claim in their coinbase transaction",
+                      "skip_type_check": false,
+                      "key_name": "unclaimed_rewards",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "gettxspendingprevout": {
+      "category": "blockchain",
+      "description": "Scans the mempool to find transactions spending any of the given outputs",
+      "examples": "> bitcoin-cli gettxspendingprevout \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":3}]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"gettxspendingprevout\", \"params\": [\"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":3}]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "gettxspendingprevout",
+      "argument_names": [
+        "outputs"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "outputs"
+          ],
+          "description": "The transaction outputs that we want to check, and within each, the txid (string) vout (numeric).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "the transaction id of the checked output",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "the vout value of the checked output",
+                  "skip_type_check": false,
+                  "key_name": "vout",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": true,
+                  "description": "the transaction id of the mempool transaction spending this output (omitted if unspent)",
+                  "skip_type_check": false,
+                  "key_name": "spendingtxid",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "getunconfirmedbalance": {
+      "category": "wallet",
+      "description": "DEPRECATED\nIdentical to getbalances().mine.untrusted_pending\n",
+      "examples": "",
+      "name": "getunconfirmedbalance",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "The balance",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "getwalletinfo": {
+      "category": "wallet",
+      "description": "Returns an object containing various wallet state info.\n",
+      "examples": "> bitcoin-cli getwalletinfo \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"getwalletinfo\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "getwalletinfo",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the wallet name",
+              "skip_type_check": false,
+              "key_name": "walletname",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the wallet version",
+              "skip_type_check": false,
+              "key_name": "walletversion",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the database format (bdb or sqlite)",
+              "skip_type_check": false,
+              "key_name": "format",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "DEPRECATED. Identical to getbalances().mine.trusted",
+              "skip_type_check": false,
+              "key_name": "balance",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "DEPRECATED. Identical to getbalances().mine.untrusted_pending",
+              "skip_type_check": false,
+              "key_name": "unconfirmed_balance",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "DEPRECATED. Identical to getbalances().mine.immature",
+              "skip_type_check": false,
+              "key_name": "immature_balance",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the total number of transactions in the wallet",
+              "skip_type_check": false,
+              "key_name": "txcount",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "the UNIX epoch time of the oldest pre-generated key in the key pool. Legacy wallets only.",
+              "skip_type_check": false,
+              "key_name": "keypoololdest",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "how many new keys are pre-generated (only counts external keys)",
+              "skip_type_check": false,
+              "key_name": "keypoolsize",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)",
+              "skip_type_check": false,
+              "key_name": "keypoolsize_hd_internal",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "the UNIX epoch time until which the wallet is unlocked for transfers, or 0 if the wallet is locked (only present for passphrase-encrypted wallets)",
+              "skip_type_check": false,
+              "key_name": "unlocked_until",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "the transaction fee configuration, set in BTC/kvB",
+              "skip_type_check": false,
+              "key_name": "paytxfee",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "the Hash160 of the HD seed (only present when HD is enabled)",
+              "skip_type_check": false,
+              "key_name": "hdseedid",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "false if privatekeys are disabled for this wallet (enforced watch-only wallet)",
+              "skip_type_check": false,
+              "key_name": "private_keys_enabled",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "whether this wallet tracks clean/dirty coins in terms of reuse",
+              "skip_type_check": false,
+              "key_name": "avoid_reuse",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "current scanning details, or false if no scan is in progress",
+              "skip_type_check": true,
+              "key_name": "scanning",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "elapsed seconds since scan start",
+                  "skip_type_check": false,
+                  "key_name": "duration",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "scanning progress percentage [0.0, 1.0]",
+                  "skip_type_check": false,
+                  "key_name": "progress",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "whether this wallet uses descriptors for output script management",
+              "skip_type_check": false,
+              "key_name": "descriptors",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "whether this wallet is configured to use an external signer such as a hardware wallet",
+              "skip_type_check": false,
+              "key_name": "external_signer",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether this wallet intentionally does not contain any keys, scripts, or descriptors",
+              "skip_type_check": false,
+              "key_name": "blank",
+              "condition": ""
+            },
+            {
+              "type": "timestamp",
+              "optional": true,
+              "description": "The start time for blocks scanning. It could be modified by (re)importing any descriptor with an earlier timestamp.",
+              "skip_type_check": false,
+              "key_name": "birthtime",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "hash and height of the block this information was generated on",
+              "skip_type_check": false,
+              "key_name": "lastprocessedblock",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "hash of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "hash",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "height of the block this information was generated on",
+                  "skip_type_check": false,
+                  "key_name": "height",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "help": {
+      "category": "control",
+      "description": "\nList all commands, or get help for a specified command.\n",
+      "examples": "",
+      "name": "help",
+      "argument_names": [
+        "command"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "command"
+          ],
+          "description": "The command to get help on",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "all commands",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The help text",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        },
+        {
+          "type": "any",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importaddress": {
+      "category": "wallet",
+      "description": "\nAdds an address or script (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.\n\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\nmay report that the imported address exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.\nThe rescan parameter can be set to false if the key was never used to create transactions. If it is set to false,\nbut the key was used to create transactions, rescanblockchain needs to be called with the appropriate block range.\nIf you have the full public key, you should call importpubkey instead of this.\nHint: use importmulti to import more than one address.\n\nNote: If you import a non-standard raw script in hex form, outputs sending to it will be treated\nas change, and not show up in many RPCs.\nNote: Use \"getwalletinfo\" to query the scanning progress.\nNote: This command is only compatible with legacy wallets. Use \"importdescriptors\" for descriptor wallets.\n",
+      "examples": "\nImport an address with rescan\n> bitcoin-cli importaddress \"myaddress\"\n\nImport using a label without rescan\n> bitcoin-cli importaddress \"myaddress\" \"testing\" false\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"importaddress\", \"params\": [\"myaddress\", \"testing\", false]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "importaddress",
+      "argument_names": [
+        "address",
+        "label",
+        "rescan",
+        "p2sh"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The Bitcoin address (or hex-encoded script)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "An optional label",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "rescan"
+          ],
+          "description": "Scan the chain and mempool for wallet transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "p2sh"
+          ],
+          "description": "Add the P2SH version of the script as well",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importdescriptors": {
+      "category": "wallet",
+      "description": "\nImport descriptors. This will trigger a rescan of the blockchain based on the earliest timestamp of all descriptors being imported. Requires a new wallet backup.\nWhen importing descriptors with multipath key expressions, if the multipath specifier contains exactly two elements, the descriptor produced from the second elements will be imported as an internal descriptor.\n\nNote: This call can take over an hour to complete if using an early timestamp; during that time, other rpc calls\nmay report that the imported keys, addresses or scripts exist but related transactions are still missing.\nThe rescan is significantly faster if block filters are available (using startup option \"-blockfilterindex=1\").\n",
+      "examples": "> bitcoin-cli importdescriptors '[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"internal\": true }, { \"desc\": \"<my descriptor 2>\", \"label\": \"example 2\", \"timestamp\": 1455191480 }]'\n> bitcoin-cli importdescriptors '[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my bech32 wallet>\" }]'\n",
+      "name": "importdescriptors",
+      "argument_names": [
+        "requests"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "requests"
+          ],
+          "description": "Data to be imported",
+          "oneline_description": "requests",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "Descriptor to import.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "active"
+                  ],
+                  "description": "Set this descriptor to be the active descriptor for the corresponding output type/externality",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": false,
+                  "hidden": false,
+                  "type": "boolean"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "range"
+                },
+                {
+                  "names": [
+                    "next_index"
+                  ],
+                  "description": "If a ranged descriptor is set to active, this specifies the next index to generate addresses from",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "timestamp"
+                  ],
+                  "description": "Time from which to start rescanning the blockchain for this descriptor, in UNIX epoch time\nUse the string \"now\" to substitute the current synced blockchain time.\n\"now\" can be specified to bypass scanning, for outputs which are known to never have been used, and\n0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest timestamp\nof all descriptors being imported will be scanned as well as the mempool.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [
+                    "timestamp | \"now\"",
+                    "integer / string"
+                  ],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "internal"
+                  ],
+                  "description": "Whether matching outputs should be treated as not incoming payments (e.g. change)",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": false,
+                  "hidden": false,
+                  "type": "boolean"
+                },
+                {
+                  "names": [
+                    "label"
+                  ],
+                  "description": "Label to assign to the address, only allowed with internal=false. Disabled for ranged descriptors",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": "",
+                  "hidden": false,
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "Response is an array with the same size as the input that has the execution result",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "success",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": true,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "warnings",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "optional": true,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "error",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "elision",
+                      "optional": false,
+                      "description": "JSONRPC error",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "importmempool": {
+      "category": "blockchain",
+      "description": "Import a mempool.dat file and attempt to add its contents to the mempool.\nWarning: Importing untrusted files is dangerous, especially if metadata from the file is taken over.",
+      "examples": "> bitcoin-cli importmempool /path/to/mempool.dat\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"importmempool\", \"params\": [/path/to/mempool.dat]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "importmempool",
+      "argument_names": [
+        "filepath",
+        "use_current_time",
+        "apply_fee_delta_priority",
+        "apply_unbroadcast_set",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "filepath"
+          ],
+          "description": "The mempool file",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "use_current_time"
+              ],
+              "description": "Whether to use the current system time or use the entry time metadata from the mempool file.\nWarning: Importing untrusted metadata may lead to unexpected issues and undesirable behavior.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "apply_fee_delta_priority"
+              ],
+              "description": "Whether to apply the fee delta metadata from the mempool file.\nIt will be added to any existing fee deltas.\nThe fee delta can be set by the prioritisetransaction RPC.\nWarning: Importing untrusted metadata may lead to unexpected issues and undesirable behavior.\nOnly set this bool if you understand what it does.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "apply_unbroadcast_set"
+              ],
+              "description": "Whether to apply the unbroadcast set metadata from the mempool file.\nWarning: Importing untrusted metadata may lead to unexpected issues and undesirable behavior.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importmulti": {
+      "category": "wallet",
+      "description": "\nImport addresses/scripts (with private or public keys, redeem script (P2SH)), optionally rescanning the blockchain from the earliest creation time of the imported scripts. Requires a new wallet backup.\nIf an address/script is imported without all of the private keys required to spend from that address, it will be watchonly. The 'watchonly' option must be set to true in this case or a warning will be returned.\nConversely, if all the private keys are provided and the address/script is spendable, the watchonly option must be set to false, or a warning will be returned.\n\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\nmay report that the imported keys, addresses or scripts exist but related transactions are still missing.\nThe rescan parameter can be set to false if the key was never used to create transactions. If it is set to false,\nbut the key was used to create transactions, rescanblockchain needs to be called with the appropriate block range.\nNote: Use \"getwalletinfo\" to query the scanning progress.\nNote: This command is only compatible with legacy wallets. Use \"importdescriptors\" for descriptor wallets.\n",
+      "examples": "> bitcoin-cli importmulti '[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }, { \"scriptPubKey\": { \"address\": \"<my 2nd address>\" }, \"label\": \"example 2\", \"timestamp\": 1455191480 }]'\n> bitcoin-cli importmulti '[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }]' '{ \"rescan\": false}'\n",
+      "name": "importmulti",
+      "argument_names": [
+        "requests",
+        "rescan",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "requests"
+          ],
+          "description": "Data to be imported",
+          "oneline_description": "requests",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "Descriptor to import. If using descriptor, do not also provide address/scriptPubKey, scripts, or pubkeys",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "scriptPubKey"
+                  ],
+                  "description": "Type of scriptPubKey (string for script, json for address). Should not be provided if using a descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [
+                    "\"<script>\" | { \"address\":\"<address>\" }",
+                    "string / json"
+                  ],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "timestamp"
+                  ],
+                  "description": "Creation time of the key expressed in UNIX epoch time,\nor the string \"now\" to substitute the current synced blockchain time. The timestamp of the oldest\nkey will determine how far back blockchain rescans need to begin for missing wallet transactions.\n\"now\" can be specified to bypass scanning, for keys which are known to never have been used, and\n0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest key\ncreation time of all keys being imported by the importmulti call will be scanned.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [
+                    "timestamp | \"now\"",
+                    "integer / string"
+                  ],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "redeemscript"
+                  ],
+                  "description": "Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "witnessscript"
+                  ],
+                  "description": "Allowed only if the scriptPubKey is a P2SH-P2WSH or P2WSH address/scriptPubKey",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "pubkeys"
+                  ],
+                  "description": "Array of strings giving pubkeys to import. They must occur in P2PKH or P2WPKH scripts. They are not required when the private key is also provided (see the \"keys\" argument).",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "pubKey"
+                      ],
+                      "description": "",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "keys"
+                  ],
+                  "description": "Array of strings giving private keys to import. The corresponding public keys must occur in the output or redeemscript.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "key"
+                      ],
+                      "description": "",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "range"
+                },
+                {
+                  "names": [
+                    "internal"
+                  ],
+                  "description": "Stating whether matching outputs should be treated as not incoming payments (also known as change)",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": false,
+                  "hidden": false,
+                  "type": "boolean"
+                },
+                {
+                  "names": [
+                    "watchonly"
+                  ],
+                  "description": "Stating whether matching outputs should be considered watchonly.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": false,
+                  "hidden": false,
+                  "type": "boolean"
+                },
+                {
+                  "names": [
+                    "label"
+                  ],
+                  "description": "Label to assign to the address, only allowed with internal=false",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": "",
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "keypool"
+                  ],
+                  "description": "Stating whether imported public keys should be added to the keypool for when users request new addresses. Only allowed when wallet private keys are disabled",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": false,
+                  "hidden": false,
+                  "type": "boolean"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "rescan"
+              ],
+              "description": "Scan the chain and mempool for wallet transactions after all imports.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "Response is an array with the same size as the input that has the execution result",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "success",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": true,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "warnings",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "optional": true,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "error",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "elision",
+                      "optional": false,
+                      "description": "JSONRPC error",
+                      "skip_type_check": false,
+                      "key_name": "",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "importprivkey": {
+      "category": "wallet",
+      "description": "\nAdds a private key (as returned by dumpprivkey) to your wallet. Requires a new wallet backup.\nHint: use importmulti to import more than one private key.\n\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\nmay report that the imported key exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.\nThe rescan parameter can be set to false if the key was never used to create transactions. If it is set to false,\nbut the key was used to create transactions, rescanblockchain needs to be called with the appropriate block range.\nNote: Use \"getwalletinfo\" to query the scanning progress.\nNote: This command is only compatible with legacy wallets. Use \"importdescriptors\" with \"combo(X)\" for descriptor wallets.\n",
+      "examples": "\nDump a private key\n> bitcoin-cli dumpprivkey \"myaddress\"\n\nImport the private key with rescan\n> bitcoin-cli importprivkey \"mykey\"\n\nImport using a label and without rescan\n> bitcoin-cli importprivkey \"mykey\" \"testing\" false\n\nImport using default blank label and without rescan\n> bitcoin-cli importprivkey \"mykey\" \"\" false\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"importprivkey\", \"params\": [\"mykey\", \"testing\", false]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "importprivkey",
+      "argument_names": [
+        "privkey",
+        "label",
+        "rescan"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "privkey"
+          ],
+          "description": "The private key (see dumpprivkey)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "An optional label",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "current label if address exists, otherwise \"\"",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "rescan"
+          ],
+          "description": "Scan the chain and mempool for wallet transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importprunedfunds": {
+      "category": "wallet",
+      "description": "\nImports funds without rescan. Corresponding address or script must previously be included in wallet. Aimed towards pruned wallets. The end-user is responsible to import additional transactions that subsequently spend the imported outputs or rescan after the point in the blockchain the transaction is included.\n",
+      "examples": "",
+      "name": "importprunedfunds",
+      "argument_names": [
+        "rawtransaction",
+        "txoutproof"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "rawtransaction"
+          ],
+          "description": "A raw transaction in hex funding an already-existing address in wallet",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "txoutproof"
+          ],
+          "description": "The hex output from gettxoutproof that contains the transaction",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importpubkey": {
+      "category": "wallet",
+      "description": "\nAdds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.\nHint: use importmulti to import more than one public key.\n\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\nmay report that the imported pubkey exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.\nThe rescan parameter can be set to false if the key was never used to create transactions. If it is set to false,\nbut the key was used to create transactions, rescanblockchain needs to be called with the appropriate block range.\nNote: Use \"getwalletinfo\" to query the scanning progress.\nNote: This command is only compatible with legacy wallets. Use \"importdescriptors\" with \"combo(X)\" for descriptor wallets.\n",
+      "examples": "\nImport a public key with rescan\n> bitcoin-cli importpubkey \"mypubkey\"\n\nImport using a label without rescan\n> bitcoin-cli importpubkey \"mypubkey\" \"testing\" false\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"importpubkey\", \"params\": [\"mypubkey\", \"testing\", false]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "importpubkey",
+      "argument_names": [
+        "pubkey",
+        "label",
+        "rescan"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "pubkey"
+          ],
+          "description": "The hex-encoded public key",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "An optional label",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "rescan"
+          ],
+          "description": "Scan the chain and mempool for wallet transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "importwallet": {
+      "category": "wallet",
+      "description": "\nImports keys from a wallet dump file (see dumpwallet). Requires a new wallet backup to include imported keys.\nNote: Blockchain and Mempool will be rescanned after a successful import. Use \"getwalletinfo\" to query the scanning progress.\nNote: This command is only compatible with legacy wallets.\n",
+      "examples": "\nDump the wallet\n> bitcoin-cli dumpwallet \"test\"\n\nImport the wallet\n> bitcoin-cli importwallet \"test\"\n\nImport using the json rpc call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"importwallet\", \"params\": [\"test\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "importwallet",
+      "argument_names": [
+        "filename"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "filename"
+          ],
+          "description": "The wallet file",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "invalidateblock": {
+      "category": "hidden",
+      "description": "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n",
+      "examples": "> bitcoin-cli invalidateblock \"blockhash\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"invalidateblock\", \"params\": [\"blockhash\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "invalidateblock",
+      "argument_names": [
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "the hash of the block to mark as invalid",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "joinpsbts": {
+      "category": "rawtransactions",
+      "description": "\nJoins multiple distinct PSBTs with different inputs and outputs into one PSBT with inputs and outputs from all of the PSBTs\nNo input in any of the PSBTs can be in more than one of the PSBTs.\n",
+      "examples": "> bitcoin-cli joinpsbts \"psbt\"\n",
+      "name": "joinpsbts",
+      "argument_names": [
+        "txs"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txs"
+          ],
+          "description": "The base64 strings of partially signed transactions",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "psbt"
+              ],
+              "description": "A base64 string of a PSBT",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": true,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The base64-encoded partially signed transaction",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "keypoolrefill": {
+      "category": "wallet",
+      "description": "\nFills the keypool.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "> bitcoin-cli keypoolrefill \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"keypoolrefill\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "keypoolrefill",
+      "argument_names": [
+        "newsize"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "newsize"
+          ],
+          "description": "The new keypool size",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "1000, or as set by -keypool",
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "listaddressgroupings": {
+      "category": "wallet",
+      "description": "\nLists groups of addresses which have had their common ownership\nmade public by common use as inputs or as the resulting change\nin past transactions\n",
+      "examples": "> bitcoin-cli listaddressgroupings \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listaddressgroupings\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listaddressgroupings",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The bitcoin address",
+                      "skip_type_check": false,
+                      "key_name": "address",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The amount in BTC",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "The label",
+                      "skip_type_check": false,
+                      "key_name": "label",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listbanned": {
+      "category": "network",
+      "description": "\nList all manually banned IPs/Subnets.\n",
+      "examples": "> bitcoin-cli listbanned \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listbanned\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listbanned",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The IP/Subnet of the banned node",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time the ban was created",
+                  "skip_type_check": false,
+                  "key_name": "ban_created",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The UNIX epoch time the ban expires",
+                  "skip_type_check": false,
+                  "key_name": "banned_until",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The ban duration, in seconds",
+                  "skip_type_check": false,
+                  "key_name": "ban_duration",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The time remaining until the ban expires, in seconds",
+                  "skip_type_check": false,
+                  "key_name": "time_remaining",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listdescriptors": {
+      "category": "wallet",
+      "description": "\nList descriptors imported into a descriptor-enabled wallet.\n",
+      "examples": "> bitcoin-cli listdescriptors \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listdescriptors\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli listdescriptors true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listdescriptors\", \"params\": [true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listdescriptors",
+      "argument_names": [
+        "private"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "private"
+          ],
+          "description": "Show private descriptors.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Name of wallet this operation was performed on",
+              "skip_type_check": false,
+              "key_name": "wallet_name",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Array of descriptor objects (sorted by descriptor string representation)",
+              "skip_type_check": false,
+              "key_name": "descriptors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "Descriptor string representation",
+                      "skip_type_check": false,
+                      "key_name": "desc",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The creation time of the descriptor",
+                      "skip_type_check": false,
+                      "key_name": "timestamp",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "Whether this descriptor is currently used to generate new addresses",
+                      "skip_type_check": false,
+                      "key_name": "active",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": true,
+                      "description": "True if this descriptor is used to generate change addresses. False if this descriptor is used to generate receiving addresses; defined only for active descriptors",
+                      "skip_type_check": false,
+                      "key_name": "internal",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "Defined only for ranged descriptors",
+                      "skip_type_check": false,
+                      "key_name": "range",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "Range start inclusive",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        },
+                        {
+                          "type": "number",
+                          "optional": false,
+                          "description": "Range end inclusive",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "Same as next_index field. Kept for compatibility reason.",
+                      "skip_type_check": false,
+                      "key_name": "next",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The next index to generate addresses from; defined only for ranged descriptors",
+                      "skip_type_check": false,
+                      "key_name": "next_index",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listlabels": {
+      "category": "wallet",
+      "description": "\nReturns the list of all labels, or labels that are assigned to addresses with a specific purpose.\n",
+      "examples": "\nList all labels\n> bitcoin-cli listlabels \n\nList labels that have receiving addresses\n> bitcoin-cli listlabels receive\n\nList labels that have sending addresses\n> bitcoin-cli listlabels send\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listlabels\", \"params\": [receive]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listlabels",
+      "argument_names": [
+        "purpose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "purpose"
+          ],
+          "description": "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Label name",
+              "skip_type_check": false,
+              "key_name": "label",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "listlockunspent": {
+      "category": "wallet",
+      "description": "\nReturns list of temporarily unspendable outputs.\nSee the lockunspent call to lock and unlock transactions for spending.\n",
+      "examples": "\nList the unspent transactions\n> bitcoin-cli listunspent \n\nLock an unspent transaction\n> bitcoin-cli lockunspent false \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"\n\nList the locked transactions\n> bitcoin-cli listlockunspent \n\nUnlock the transaction again\n> bitcoin-cli lockunspent true \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listlockunspent\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listlockunspent",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id locked",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The vout value",
+                  "skip_type_check": false,
+                  "key_name": "vout",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listreceivedbyaddress": {
+      "category": "wallet",
+      "description": "\nList balances by receiving address.\n",
+      "examples": "> bitcoin-cli listreceivedbyaddress \n> bitcoin-cli listreceivedbyaddress 6 true\n> bitcoin-cli listreceivedbyaddress 6 true true \"\" true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true, \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\", true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listreceivedbyaddress",
+      "argument_names": [
+        "minconf",
+        "include_empty",
+        "include_watchonly",
+        "address_filter",
+        "include_immature_coinbase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "The minimum number of confirmations before payments are included.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_empty"
+          ],
+          "description": "Whether to include addresses that haven't received any payments.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Whether to include watch-only addresses (see 'importaddress')",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "address_filter"
+          ],
+          "description": "If present and non-empty, only return information on this address.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "include_immature_coinbase"
+          ],
+          "description": "Include immature coinbase transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Only returns true if imported addresses were involved in transaction",
+                  "skip_type_check": false,
+                  "key_name": "involvesWatchonly",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The receiving address",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "The total amount in BTC received by the address",
+                  "skip_type_check": false,
+                  "key_name": "amount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The number of confirmations of the most recent transaction included",
+                  "skip_type_check": false,
+                  "key_name": "confirmations",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The label of the receiving address. The default label is \"\"",
+                  "skip_type_check": false,
+                  "key_name": "label",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "txids",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The ids of transactions received with the address",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listreceivedbylabel": {
+      "category": "wallet",
+      "description": "\nList received transactions by label.\n",
+      "examples": "> bitcoin-cli listreceivedbylabel \n> bitcoin-cli listreceivedbylabel 6 true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listreceivedbylabel\", \"params\": [6, true, true, true]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listreceivedbylabel",
+      "argument_names": [
+        "minconf",
+        "include_empty",
+        "include_watchonly",
+        "include_immature_coinbase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "The minimum number of confirmations before payments are included.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_empty"
+          ],
+          "description": "Whether to include labels that haven't received any payments.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Whether to include watch-only addresses (see 'importaddress')",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "include_immature_coinbase"
+          ],
+          "description": "Include immature coinbase transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Only returns true if imported addresses were involved in transaction",
+                  "skip_type_check": false,
+                  "key_name": "involvesWatchonly",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "The total amount received by addresses with this label",
+                  "skip_type_check": false,
+                  "key_name": "amount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The number of confirmations of the most recent transaction included",
+                  "skip_type_check": false,
+                  "key_name": "confirmations",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The label of the receiving address. The default label is \"\"",
+                  "skip_type_check": false,
+                  "key_name": "label",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listsinceblock": {
+      "category": "wallet",
+      "description": "\nGet all transactions in blocks since block [blockhash], or all transactions if omitted.\nIf \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included.\nAdditionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.\n",
+      "examples": "> bitcoin-cli listsinceblock \n> bitcoin-cli listsinceblock \"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\" 6\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listsinceblock\", \"params\": [\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\", 6]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listsinceblock",
+      "argument_names": [
+        "blockhash",
+        "target_confirmations",
+        "include_watchonly",
+        "include_removed",
+        "include_change",
+        "label"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "If set, the block hash to list transactions since, otherwise list all transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "target_confirmations"
+          ],
+          "description": "Return the nth block hash from the main chain. e.g. 1 would mean the best block hash. Note: this is not used as a filter, but only affects [lastblock] in the return value",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Include transactions to watch-only addresses (see 'importaddress')",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "include_removed"
+          ],
+          "description": "Show transactions that were removed due to a reorg in the \"removed\" array\n(not guaranteed to work on pruned nodes)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "include_change"
+          ],
+          "description": "Also add entries for change outputs.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "Return only incoming transactions paying to addresses with the specified label.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "transactions",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "boolean",
+                      "optional": true,
+                      "description": "Only returns true if imported addresses were involved in transaction.",
+                      "skip_type_check": false,
+                      "key_name": "involvesWatchonly",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "The bitcoin address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data).",
+                      "skip_type_check": false,
+                      "key_name": "address",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The transaction category.\n\"send\"                  Transactions sent.\n\"receive\"               Non-coinbase transactions received.\n\"generate\"              Coinbase transactions received with more than 100 confirmations.\n\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n\"orphan\"                Orphaned coinbase transactions received.",
+                      "skip_type_check": false,
+                      "key_name": "category",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The amount in BTC. This is negative for the 'send' category, and is positive\nfor all other categories",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "the vout value",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": true,
+                      "description": "The amount of the fee in BTC. This is negative and only available for the\n'send' category of transactions.",
+                      "skip_type_check": false,
+                      "key_name": "fee",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The number of confirmations for the transaction. Negative confirmations means the\ntransaction conflicted that many blocks ago.",
+                      "skip_type_check": false,
+                      "key_name": "confirmations",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": true,
+                      "description": "Only present if the transaction's only input is a coinbase one.",
+                      "skip_type_check": false,
+                      "key_name": "generated",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": true,
+                      "description": "Whether we consider the transaction to be trusted and safe to spend from.\nOnly present when the transaction has 0 confirmations (or negative confirmations, if conflicted).",
+                      "skip_type_check": false,
+                      "key_name": "trusted",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The block hash containing the transaction.",
+                      "skip_type_check": false,
+                      "key_name": "blockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The block height containing the transaction.",
+                      "skip_type_check": false,
+                      "key_name": "blockheight",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "The index of the transaction in the block that includes it.",
+                      "skip_type_check": false,
+                      "key_name": "blockindex",
+                      "condition": ""
+                    },
+                    {
+                      "type": "timestamp",
+                      "optional": true,
+                      "description": "The block time expressed in UNIX epoch time.",
+                      "skip_type_check": false,
+                      "key_name": "blocktime",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The transaction id.",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hash of serialized transaction, including witness data.",
+                      "skip_type_check": false,
+                      "key_name": "wtxid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "Confirmed transactions that have been detected by the wallet to conflict with this transaction.",
+                      "skip_type_check": false,
+                      "key_name": "walletconflicts",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The transaction id.",
+                          "skip_type_check": false,
+                          "key_name": "txid",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "Only if 'category' is 'send'. The txid if this tx was replaced.",
+                      "skip_type_check": false,
+                      "key_name": "replaced_by_txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "Only if 'category' is 'send'. The txid if this tx replaces another.",
+                      "skip_type_check": false,
+                      "key_name": "replaces_txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "Transactions in the mempool that directly conflict with either this transaction or an ancestor transaction",
+                      "skip_type_check": false,
+                      "key_name": "mempoolconflicts",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "The transaction id.",
+                          "skip_type_check": false,
+                          "key_name": "txid",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "If a comment to is associated with the transaction.",
+                      "skip_type_check": false,
+                      "key_name": "to",
+                      "condition": ""
+                    },
+                    {
+                      "type": "timestamp",
+                      "optional": false,
+                      "description": "The transaction time expressed in UNIX epoch time.",
+                      "skip_type_check": false,
+                      "key_name": "time",
+                      "condition": ""
+                    },
+                    {
+                      "type": "timestamp",
+                      "optional": false,
+                      "description": "The time received expressed in UNIX epoch time.",
+                      "skip_type_check": false,
+                      "key_name": "timereceived",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "If a comment is associated with the transaction, only present if not empty.",
+                      "skip_type_check": false,
+                      "key_name": "comment",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "(\"yes|no|unknown\") Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability.\nMay be unknown for unconfirmed transactions not in the mempool because their unconfirmed ancestors are unknown.",
+                      "skip_type_check": false,
+                      "key_name": "bip125-replaceable",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": true,
+                      "description": "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.",
+                      "skip_type_check": false,
+                      "key_name": "parent_descs",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "string",
+                          "optional": false,
+                          "description": "The descriptor string.",
+                          "skip_type_check": false,
+                          "key_name": "desc",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "'true' if the transaction has been abandoned (inputs are respendable).",
+                      "skip_type_check": false,
+                      "key_name": "abandoned",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "A comment for the address/transaction, if any",
+                      "skip_type_check": false,
+                      "key_name": "label",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "<structure is the same as \"transactions\" above, only present if include_removed=true>\nNote: transactions that were re-added in the active chain will appear as-is in this array, and may thus have a positive confirmation count.",
+              "skip_type_check": false,
+              "key_name": "removed",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "elision",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of the block (target_confirmations-1) from the best block on the main chain, or the genesis hash if the referenced block does not exist yet. This is typically used to feed back into listsinceblock the next time you call it. So you would generally use a target_confirmations of say 6, so you will be continually re-notified of transactions until they've reached 6 confirmations plus any new ones",
+              "skip_type_check": false,
+              "key_name": "lastblock",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "listtransactions": {
+      "category": "wallet",
+      "description": "\nIf a label name is provided, this will return only incoming transactions paying to addresses with the specified label.\n\nReturns up to 'count' most recent transactions skipping the first 'from' transactions.\n",
+      "examples": "\nList the most recent 10 transactions in the systems\n> bitcoin-cli listtransactions \n\nList transactions 100 to 120\n> bitcoin-cli listtransactions \"*\" 20 100\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listtransactions\", \"params\": [\"*\", 20, 100]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listtransactions",
+      "argument_names": [
+        "label",
+        "count",
+        "skip",
+        "include_watchonly"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "label"
+          ],
+          "description": "If set, should be a valid label name to return only incoming transactions\nwith the specified label, or \"*\" to disable filtering and return all transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "count"
+          ],
+          "description": "The number of transactions to return",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 10,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "skip"
+          ],
+          "description": "The number of transactions to skip",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "include_watchonly"
+          ],
+          "description": "Include transactions to watch-only addresses (see 'importaddress')",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "true for watch-only wallets, otherwise false",
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Only returns true if imported addresses were involved in transaction.",
+                  "skip_type_check": false,
+                  "key_name": "involvesWatchonly",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "The bitcoin address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data).",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "The transaction category.\n\"send\"                  Transactions sent.\n\"receive\"               Non-coinbase transactions received.\n\"generate\"              Coinbase transactions received with more than 100 confirmations.\n\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n\"orphan\"                Orphaned coinbase transactions received.",
+                  "skip_type_check": false,
+                  "key_name": "category",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "The amount in BTC. This is negative for the 'send' category, and is positive\nfor all other categories",
+                  "skip_type_check": false,
+                  "key_name": "amount",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "A comment for the address/transaction, if any",
+                  "skip_type_check": false,
+                  "key_name": "label",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "the vout value",
+                  "skip_type_check": false,
+                  "key_name": "vout",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": true,
+                  "description": "The amount of the fee in BTC. This is negative and only available for the\n'send' category of transactions.",
+                  "skip_type_check": false,
+                  "key_name": "fee",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The number of confirmations for the transaction. Negative confirmations means the\ntransaction conflicted that many blocks ago.",
+                  "skip_type_check": false,
+                  "key_name": "confirmations",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Only present if the transaction's only input is a coinbase one.",
+                  "skip_type_check": false,
+                  "key_name": "generated",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Whether we consider the transaction to be trusted and safe to spend from.\nOnly present when the transaction has 0 confirmations (or negative confirmations, if conflicted).",
+                  "skip_type_check": false,
+                  "key_name": "trusted",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": true,
+                  "description": "The block hash containing the transaction.",
+                  "skip_type_check": false,
+                  "key_name": "blockhash",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The block height containing the transaction.",
+                  "skip_type_check": false,
+                  "key_name": "blockheight",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The index of the transaction in the block that includes it.",
+                  "skip_type_check": false,
+                  "key_name": "blockindex",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": true,
+                  "description": "The block time expressed in UNIX epoch time.",
+                  "skip_type_check": false,
+                  "key_name": "blocktime",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id.",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The hash of serialized transaction, including witness data.",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "Confirmed transactions that have been detected by the wallet to conflict with this transaction.",
+                  "skip_type_check": false,
+                  "key_name": "walletconflicts",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The transaction id.",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "hex",
+                  "optional": true,
+                  "description": "Only if 'category' is 'send'. The txid if this tx was replaced.",
+                  "skip_type_check": false,
+                  "key_name": "replaced_by_txid",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": true,
+                  "description": "Only if 'category' is 'send'. The txid if this tx replaces another.",
+                  "skip_type_check": false,
+                  "key_name": "replaces_txid",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "Transactions in the mempool that directly conflict with either this transaction or an ancestor transaction",
+                  "skip_type_check": false,
+                  "key_name": "mempoolconflicts",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The transaction id.",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "If a comment to is associated with the transaction.",
+                  "skip_type_check": false,
+                  "key_name": "to",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The transaction time expressed in UNIX epoch time.",
+                  "skip_type_check": false,
+                  "key_name": "time",
+                  "condition": ""
+                },
+                {
+                  "type": "timestamp",
+                  "optional": false,
+                  "description": "The time received expressed in UNIX epoch time.",
+                  "skip_type_check": false,
+                  "key_name": "timereceived",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "If a comment is associated with the transaction, only present if not empty.",
+                  "skip_type_check": false,
+                  "key_name": "comment",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "(\"yes|no|unknown\") Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability.\nMay be unknown for unconfirmed transactions not in the mempool because their unconfirmed ancestors are unknown.",
+                  "skip_type_check": false,
+                  "key_name": "bip125-replaceable",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": true,
+                  "description": "Only if 'category' is 'received'. List of parent descriptors for the output script of this coin.",
+                  "skip_type_check": false,
+                  "key_name": "parent_descs",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The descriptor string.",
+                      "skip_type_check": false,
+                      "key_name": "desc",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "'true' if the transaction has been abandoned (inputs are respendable).",
+                  "skip_type_check": false,
+                  "key_name": "abandoned",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listunspent": {
+      "category": "wallet",
+      "description": "\nReturns array of unspent transaction outputs\nwith between minconf and maxconf (inclusive) confirmations.\nOptionally filter to only include txouts paid to specified addresses.\n",
+      "examples": "> bitcoin-cli listunspent \n> bitcoin-cli listunspent 6 9999999 \"[\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\",\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\"]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999 \"[\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\",\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\"]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli listunspent 6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listunspent",
+      "argument_names": [
+        "minconf",
+        "maxconf",
+        "addresses",
+        "include_unsafe",
+        "minimumAmount",
+        "maximumAmount",
+        "maximumCount",
+        "minimumSumAmount",
+        "include_immature_coinbase",
+        "query_options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "The minimum confirmations to filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 1,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "maxconf"
+          ],
+          "description": "The maximum confirmations to filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 9999999,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "addresses"
+          ],
+          "description": "The bitcoin addresses to filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": [],
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "address"
+              ],
+              "description": "bitcoin address",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "names": [
+            "include_unsafe"
+          ],
+          "description": "Include outputs that are not safe to spend\nSee description of \"safe\" attribute below.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "query_options"
+          ],
+          "description": "",
+          "oneline_description": "query_options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "minimumAmount"
+              ],
+              "description": "Minimum value of each UTXO in BTC",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": "0.00",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "maximumAmount"
+              ],
+              "description": "Maximum value of each UTXO in BTC",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "unlimited",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "maximumCount"
+              ],
+              "description": "Maximum number of UTXOs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "unlimited",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "minimumSumAmount"
+              ],
+              "description": "Minimum sum value of all UTXOs in BTC",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "unlimited",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "include_immature_coinbase"
+              ],
+              "description": "Include immature coinbase UTXOs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "the transaction id",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "the vout value",
+                  "skip_type_check": false,
+                  "key_name": "vout",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "the bitcoin address",
+                  "skip_type_check": false,
+                  "key_name": "address",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "The associated label, or \"\" for the default label",
+                  "skip_type_check": false,
+                  "key_name": "label",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "the output script",
+                  "skip_type_check": false,
+                  "key_name": "scriptPubKey",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": false,
+                  "description": "the transaction output amount in BTC",
+                  "skip_type_check": false,
+                  "key_name": "amount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "The number of confirmations",
+                  "skip_type_check": false,
+                  "key_name": "confirmations",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The number of in-mempool ancestor transactions, including this one (if transaction is in the mempool)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorcount",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "The virtual transaction size of in-mempool ancestors, including this one (if transaction is in the mempool)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorsize",
+                  "condition": ""
+                },
+                {
+                  "type": "amount",
+                  "optional": true,
+                  "description": "The total fees of in-mempool ancestors (including this one) with fee deltas used for mining priority in sat (if transaction is in the mempool)",
+                  "skip_type_check": false,
+                  "key_name": "ancestorfees",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": true,
+                  "description": "The redeem script if the output script is P2SH",
+                  "skip_type_check": false,
+                  "key_name": "redeemScript",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "witness script if the output script is P2WSH or P2SH-P2WSH",
+                  "skip_type_check": false,
+                  "key_name": "witnessScript",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether we have the private keys to spend this output",
+                  "skip_type_check": false,
+                  "key_name": "spendable",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether we know how to spend this output, ignoring the lack of keys",
+                  "skip_type_check": false,
+                  "key_name": "solvable",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "(only present if avoid_reuse is set) Whether this output is reused/dirty (sent to an address that was previously spent from)",
+                  "skip_type_check": false,
+                  "key_name": "reused",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "(only when solvable) A descriptor for spending this output",
+                  "skip_type_check": false,
+                  "key_name": "desc",
+                  "condition": ""
+                },
+                {
+                  "type": "array",
+                  "optional": false,
+                  "description": "List of parent descriptors for the output script of this coin.",
+                  "skip_type_check": false,
+                  "key_name": "parent_descs",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The descriptor string.",
+                      "skip_type_check": false,
+                      "key_name": "desc",
+                      "condition": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "boolean",
+                  "optional": false,
+                  "description": "Whether this output is considered safe to spend. Unconfirmed transactions\nfrom outside keys and unconfirmed replacement transactions are considered unsafe\nand are not eligible for spending by fundrawtransaction and sendtoaddress.",
+                  "skip_type_check": false,
+                  "key_name": "safe",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listwalletdir": {
+      "category": "wallet",
+      "description": "Returns a list of wallets in the wallet directory.\n",
+      "examples": "> bitcoin-cli listwalletdir \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listwalletdir\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listwalletdir",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "wallets",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "The wallet name",
+                      "skip_type_check": false,
+                      "key_name": "name",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "listwallets": {
+      "category": "wallet",
+      "description": "Returns a list of currently loaded wallets.\nFor full information on the wallet, use \"getwalletinfo\"\n",
+      "examples": "> bitcoin-cli listwallets \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"listwallets\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "listwallets",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the wallet name",
+              "skip_type_check": false,
+              "key_name": "walletname",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "loadtxoutset": {
+      "category": "blockchain",
+      "description": "Load the serialized UTXO set from a file.\nOnce this snapshot is loaded, its contents will be deserialized into a second chainstate data structure, which is then used to sync to the network's tip. Meanwhile, the original chainstate will complete the initial block download process in the background, eventually validating up to the block that the snapshot is based upon.\n\nThe result is a usable bitcoind instance that is current with the network tip in a matter of minutes rather than hours. UTXO snapshot are typically obtained from third-party sources (HTTP, torrent, etc.) which is reasonable since their contents are always checked by hash.\n\nYou can find more information on this process in the `assumeutxo` design document (<https://github.com/bitcoin/bitcoin/blob/master/doc/design/assumeutxo.md>).",
+      "examples": "> bitcoin-cli -rpcclienttimeout=0 loadtxoutset utxo.dat\n",
+      "name": "loadtxoutset",
+      "argument_names": [
+        "path"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "path"
+          ],
+          "description": "path to the snapshot file. If relative, will be prefixed by datadir.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the number of coins loaded from the snapshot",
+              "skip_type_check": false,
+              "key_name": "coins_loaded",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "the hash of the base of the snapshot",
+              "skip_type_check": false,
+              "key_name": "tip_hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "the height of the base of the snapshot",
+              "skip_type_check": false,
+              "key_name": "base_height",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the absolute path that the snapshot was loaded from",
+              "skip_type_check": false,
+              "key_name": "path",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "loadwallet": {
+      "category": "wallet",
+      "description": "\nLoads a wallet from a wallet file or directory.\nNote that all wallet command-line options used when starting bitcoind will be\napplied to the new wallet.\n",
+      "examples": "\nLoad wallet from the wallet dir:\n> bitcoin-cli loadwallet \"walletname\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"loadwallet\", \"params\": [\"walletname\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n\nLoad wallet using absolute path (Unix):\n> bitcoin-cli loadwallet \"/path/to/walletname/\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"loadwallet\", \"params\": [\"/path/to/walletname/\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n\nLoad wallet using absolute path (Windows):\n> bitcoin-cli loadwallet \"DriveLetter:\\path\\to\\walletname\\\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"loadwallet\", \"params\": [\"DriveLetter:\\path\\to\\walletname\\\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "loadwallet",
+      "argument_names": [
+        "filename",
+        "load_on_startup"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "filename"
+          ],
+          "description": "The path to the directory of the wallet to be loaded, either absolute or relative to the \"wallets\" directory. The \"wallets\" directory is set by the -walletdir option and defaults to the \"wallets\" folder within the data directory.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "load_on_startup"
+          ],
+          "description": "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The wallet name if loaded successfully.",
+              "skip_type_check": false,
+              "key_name": "name",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Warning messages, if any, related to loading the wallet.",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "lockunspent": {
+      "category": "wallet",
+      "description": "\nUpdates list of temporarily unspendable outputs.\nTemporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs.\nIf no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked.\nA locked transaction output will not be chosen by automatic coin selection, when spending bitcoins.\nManually selected coins are automatically unlocked.\nLocks are stored in memory only, unless persistent=true, in which case they will be written to the\nwallet database and loaded on node start. Unwritten (persistent=false) locks are always cleared\n(by virtue of process exit) when a node stops or fails. Unlocking will clear both persistent and not.\nAlso see the listunspent call\n",
+      "examples": "\nList the unspent transactions\n> bitcoin-cli listunspent \n\nLock an unspent transaction\n> bitcoin-cli lockunspent false \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"\n\nList the locked transactions\n> bitcoin-cli listlockunspent \n\nUnlock the transaction again\n> bitcoin-cli lockunspent true \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"\n\nLock the transaction persistently in the wallet database\n> bitcoin-cli lockunspent false \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\" true\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"lockunspent\", \"params\": [false, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "lockunspent",
+      "argument_names": [
+        "unlock",
+        "transactions",
+        "persistent"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "unlock"
+          ],
+          "description": "Whether to unlock (true) or lock (false) the specified transactions",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "transactions"
+          ],
+          "description": "The transaction outputs and within each, the txid (string) vout (numeric).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": [],
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "persistent"
+          ],
+          "description": "Whether to write/erase this lock in the wallet database, or keep the change in memory only. Ignored for unlocking.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "Whether the command was successful or not",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "logging": {
+      "category": "control",
+      "description": "Gets and sets the logging configuration.\nWhen called without an argument, returns the list of categories with status that are currently being debug logged or not.\nWhen called with arguments, adds or removes categories from debug logging and return the lists above.\nThe arguments are evaluated in order \"include\", \"exclude\".\nIf an item is both included and excluded, it will thus end up being excluded.\nThe valid logging categories are: addrman, bench, blockstorage, cmpctblock, coindb, estimatefee, http, i2p, ipc, leveldb, libevent, mempool, mempoolrej, net, proxy, prune, qt, rand, reindex, rpc, scan, selectcoins, tor, txpackages, txreconciliation, validation, walletdb, zmq\nIn addition, the following are available as category names with special meanings:\n  - \"all\",  \"1\" : represent all logging categories.\n",
+      "examples": "> bitcoin-cli logging \"[\\\"all\\\"]\" \"[\\\"http\\\"]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"logging\", \"params\": [[\"all\"], [\"libevent\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "logging",
+      "argument_names": [
+        "include",
+        "exclude"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "include"
+          ],
+          "description": "The categories to add to debug logging",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "include_category"
+              ],
+              "description": "the valid logging category",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "names": [
+            "exclude"
+          ],
+          "description": "The categories to remove from debug logging",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "exclude_category"
+              ],
+              "description": "the valid logging category",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "keys are the logging categories, and values indicates its status",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "if being debug logged or not. false:inactive, true:active",
+              "skip_type_check": false,
+              "key_name": "category",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "migratewallet": {
+      "category": "wallet",
+      "description": "\nMigrate the wallet to a descriptor wallet.\nA new wallet backup will need to be made.\n\nThe migration process will create a backup of the wallet before migrating. This backup\nfile will be named <wallet name>-<timestamp>.legacy.bak and can be found in the directory\nfor this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet.\nEncrypted wallets must have the passphrase provided as an argument to this call.\n\nThis RPC may take a long time to complete. Increasing the RPC client timeout is recommended.",
+      "examples": "> bitcoin-cli migratewallet \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"migratewallet\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "migratewallet",
+      "argument_names": [
+        "wallet_name",
+        "passphrase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "wallet_name"
+          ],
+          "description": "The name of the wallet to migrate. If provided both here and in the RPC endpoint, the two must be identical.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "the wallet name from the RPC endpoint",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "passphrase"
+          ],
+          "description": "The wallet passphrase",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The name of the primary migrated wallet",
+              "skip_type_check": false,
+              "key_name": "wallet_name",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The name of the migrated wallet containing the watchonly scripts",
+              "skip_type_check": false,
+              "key_name": "watchonly_name",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The name of the migrated wallet containing solvable but not watched scripts",
+              "skip_type_check": false,
+              "key_name": "solvables_name",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The location of the backup of the original wallet",
+              "skip_type_check": false,
+              "key_name": "backup_path",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "mockscheduler": {
+      "category": "hidden",
+      "description": "\nBump the scheduler into the future (-regtest only)\n",
+      "examples": "",
+      "name": "mockscheduler",
+      "argument_names": [
+        "delta_time"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "delta_time"
+          ],
+          "description": "Number of seconds to forward the scheduler into the future.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "newkeypool": {
+      "category": "wallet",
+      "description": "\nEntirely clears and refills the keypool.\nWARNING: On non-HD wallets, this will require a new backup immediately, to include the new keys.\nWhen restoring a backup of an HD wallet created before the newkeypool command is run, funds received to\nnew addresses may not appear automatically. They have not been lost, but the wallet may not find them.\nThis can be fixed by running the newkeypool command on the backup and then rescanning, so the wallet\nre-generates the required keys.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "> bitcoin-cli newkeypool \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"newkeypool\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "newkeypool",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "ping": {
+      "category": "network",
+      "description": "\nRequests that a ping be sent to all other nodes, to measure ping time.\nResults provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\nPing command is handled in queue with all other commands, so it measures processing backlog, not just network ping.\n",
+      "examples": "> bitcoin-cli ping \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"ping\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "ping",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "preciousblock": {
+      "category": "blockchain",
+      "description": "\nTreats a block as if it were received before others with the same work.\n\nA later preciousblock call can override the effect of an earlier one.\n\nThe effects of preciousblock are not retained across restarts.\n",
+      "examples": "> bitcoin-cli preciousblock \"blockhash\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"preciousblock\", \"params\": [\"blockhash\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "preciousblock",
+      "argument_names": [
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "the hash of the block to mark as precious",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "prioritisetransaction": {
+      "category": "mining",
+      "description": "Accepts the transaction into mined blocks at a higher (or lower) priority\n",
+      "examples": "> bitcoin-cli prioritisetransaction \"txid\" 0.0 10000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"prioritisetransaction\", \"params\": [\"txid\", 0.0, 10000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "prioritisetransaction",
+      "argument_names": [
+        "txid",
+        "dummy",
+        "fee_delta"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The transaction id.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "dummy"
+          ],
+          "description": "API-Compatibility for previous API. Must be zero or null.\n                  DEPRECATED. For forward compatibility use named arguments and omit this parameter.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "fee_delta"
+          ],
+          "description": "The fee value (in satoshis) to add (or subtract, if negative).\n                  Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX.\n                  The fee is not actually paid, only the algorithm for selecting transactions into a block\n                  considers the transaction as it would have paid a higher (or lower) fee.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "Returns true",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "pruneblockchain": {
+      "category": "blockchain",
+      "description": "",
+      "examples": "> bitcoin-cli pruneblockchain 1000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"pruneblockchain\", \"params\": [1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "pruneblockchain",
+      "argument_names": [
+        "height"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "height"
+          ],
+          "description": "The block height to prune up to. May be set to a discrete height, or to a UNIX epoch time\n                  to prune blocks whose block time is at least 2 hours older than the provided timestamp.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "Height of the last block pruned",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "psbtbumpfee": {
+      "category": "wallet",
+      "description": "\nBumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B.\nReturns a PSBT instead of creating and signing a new transaction.\nAn opt-in RBF transaction with the given txid must be in the wallet.\nThe command will pay the additional fee by reducing change outputs or adding inputs when necessary.\nIt may add a new change output if one does not already exist.\nAll inputs in the original transaction will be included in the replacement transaction.\nThe command will fail if the wallet or mempool contains a transaction that spends one of T's outputs.\nBy default, the new fee will be calculated automatically using the estimatesmartfee RPC.\nThe user can specify a confirmation target for estimatesmartfee.\nAlternatively, the user can specify a fee rate in sat/vB for the new transaction.\nAt a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee\nreturned by getnetworkinfo) to enter the node's mempool.\n* WARNING: before version 0.21, fee_rate was in BTC/kvB. As of 0.21, fee_rate is in sat/vB. *\n",
+      "examples": "\nBump the fee, get the new transaction's psbt\n> bitcoin-cli psbtbumpfee <txid>\n",
+      "name": "psbtbumpfee",
+      "argument_names": [
+        "txid",
+        "conf_target",
+        "fee_rate",
+        "replaceable",
+        "estimate_mode",
+        "outputs",
+        "original_change_index",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The txid to be bumped",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "\nSpecify a fee rate in sat/vB instead of relying on the built-in fee estimator.\nMust be at least 1.000 sat/vB higher than the current transaction fee rate.\nWARNING: before version 0.21, fee_rate was in BTC/kvB. As of 0.21, fee_rate is in sat/vB.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Whether the new transaction should still be\nmarked bip-125 replaceable. If true, the sequence numbers in the transaction will\nbe left unchanged from the original. If false, any input sequence numbers in the\noriginal transaction that were less than 0xfffffffe will be increased to 0xfffffffe\nso the new transaction will not be explicitly bip-125 replaceable (though it may\nstill be replaceable in practice, for example if it has unconfirmed ancestors which\nare replaceable).\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "outputs"
+              ],
+              "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nCannot be provided if 'original_change_index' is specified.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "address"
+                      ],
+                      "description": "A key-value pair. The key (string) is the bitcoin address,\nthe value (float or string) is the amount in BTC",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "amount"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "data"
+                      ],
+                      "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "names": [
+                "original_change_index"
+              ],
+              "description": "The 0-based index of the change output on the original transaction. The indicated output will be recycled into the new change output on the bumped transaction. The remainder after paying the recipients and fees will be sent to the output script of the original change output. The change output’s amount can increase if bumping the transaction adds new inputs, otherwise it will decrease. Cannot be used in combination with the 'outputs' option.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, detect change automatically",
+              "hidden": false,
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The base64-encoded unsigned PSBT of the new transaction.",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The fee of the replaced transaction.",
+              "skip_type_check": false,
+              "key_name": "origfee",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The fee of the new transaction.",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Errors encountered during processing (may be empty).",
+              "skip_type_check": false,
+              "key_name": "errors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "reconsiderblock": {
+      "category": "hidden",
+      "description": "\nRemoves invalidity status of a block, its ancestors and its descendants, reconsider them for activation.\nThis can be used to undo the effects of invalidateblock.\n",
+      "examples": "> bitcoin-cli reconsiderblock \"blockhash\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"reconsiderblock\", \"params\": [\"blockhash\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "reconsiderblock",
+      "argument_names": [
+        "blockhash"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "the hash of the block to reconsider",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "removeprunedfunds": {
+      "category": "wallet",
+      "description": "\nDeletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n",
+      "examples": "> bitcoin-cli removeprunedfunds \"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"removeprunedfunds\", \"params\": [\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "removeprunedfunds",
+      "argument_names": [
+        "txid"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "txid"
+          ],
+          "description": "The hex-encoded id of the transaction you are deleting",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "rescanblockchain": {
+      "category": "wallet",
+      "description": "\nRescan the local blockchain for wallet related transactions.\nNote: Use \"getwalletinfo\" to query the scanning progress.\nThe rescan is significantly faster when used on a descriptor wallet\nand block filters are available (using startup option \"-blockfilterindex=1\").\n",
+      "examples": "> bitcoin-cli rescanblockchain 100000 120000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"rescanblockchain\", \"params\": [100000, 120000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "rescanblockchain",
+      "argument_names": [
+        "start_height",
+        "stop_height"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "start_height"
+          ],
+          "description": "block height where the rescan should start",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "stop_height"
+          ],
+          "description": "the last block height that should be scanned. If none is provided it will rescan up to the tip at return time of this call.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block height where the rescan started (the requested height or 0)",
+              "skip_type_check": false,
+              "key_name": "start_height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The height of the last rescanned block. May be null in rare cases if there was a reorg and the call didn't scan any blocks because they were already scanned in the background.",
+              "skip_type_check": false,
+              "key_name": "stop_height",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "restorewallet": {
+      "category": "wallet",
+      "description": "\nRestores and loads a wallet from backup.\n\nThe rescan is significantly faster if a descriptor wallet is restored\nand block filters are available (using startup option \"-blockfilterindex=1\").\n",
+      "examples": "> bitcoin-cli restorewallet \"testwallet\" \"home\\backups\\backup-file.bak\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"restorewallet\", \"params\": [\"testwallet\" \"home\\backups\\backup-file.bak\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli -named restorewallet wallet_name=testwallet backup_file='home\\backups\\backup-file.bak\"' load_on_startup=true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"restorewallet\", \"params\": {\"wallet_name\":\"testwallet\",\"backup_file\":\"home\\\\backups\\\\backup-file.bak\\\"\",\"load_on_startup\":true}}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "restorewallet",
+      "argument_names": [
+        "wallet_name",
+        "backup_file",
+        "load_on_startup"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "wallet_name"
+          ],
+          "description": "The name that will be applied to the restored wallet",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "backup_file"
+          ],
+          "description": "The backup file that will be used to restore the wallet.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "load_on_startup"
+          ],
+          "description": "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The wallet name if restored successfully.",
+              "skip_type_check": false,
+              "key_name": "name",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Warning messages, if any, related to restoring and loading the wallet.",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "savemempool": {
+      "category": "blockchain",
+      "description": "\nDumps the mempool to disk. It will fail until the previous dump is fully loaded.\n",
+      "examples": "> bitcoin-cli savemempool \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"savemempool\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "savemempool",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "the directory and file where the mempool was saved",
+              "skip_type_check": false,
+              "key_name": "filename",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "scanblocks": {
+      "category": "blockchain",
+      "description": "\nReturn relevant blockhashes for given descriptors (requires blockfilterindex).\nThis call may take several minutes. Make sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli scanblocks start '[\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"]' 300000\n> bitcoin-cli scanblocks start '[\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"]' 100 150 basic\n> bitcoin-cli scanblocks status\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scanblocks\", \"params\": [\"start\", [\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"], 300000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scanblocks\", \"params\": [\"start\", [\"addr(bcrt1q4u4nsgk6ug0sqz7r3rj9tykjxrsl0yy4d0wwte)\"], 100, 150, \"basic\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scanblocks\", \"params\": [\"status\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "scanblocks",
+      "argument_names": [
+        "action",
+        "scanobjects",
+        "start_height",
+        "stop_height",
+        "filtertype",
+        "filter_false_positives",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "action"
+          ],
+          "description": "The action to execute\n\"start\" for starting a scan\n\"abort\" for aborting the current scan (returns true when abort was successful)\n\"status\" for progress report (in %) of the current scan",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "scanobjects"
+          ],
+          "description": "Array of scan objects. Required for \"start\" action\nEvery scan object is either a string descriptor or an object:",
+          "oneline_description": "[scanobjects,...]",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "descriptor"
+              ],
+              "description": "An output descriptor",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "An object with output descriptor and metadata",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "An output descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "The range of HD chain indexes to explore (either end or [begin,end])",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": 1000,
+                  "hidden": false,
+                  "type": "range"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "start_height"
+          ],
+          "description": "Height to start to scan from",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "stop_height"
+          ],
+          "description": "Height to stop to scan",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "chain tip",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "filtertype"
+          ],
+          "description": "The type name of the filter",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "basic",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "filter_false_positives"
+              ],
+              "description": "Filter false positives (slower and may fail on pruned nodes). Otherwise they may occur at a rate of 1/M",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "when action=='status' and no scan is in progress - possibly already completed"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "When action=='start'; only returns after scan completes",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The height we started the scan from",
+              "skip_type_check": false,
+              "key_name": "from_height",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The height we ended the scan at",
+              "skip_type_check": false,
+              "key_name": "to_height",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "Blocks that may have matched a scanobject.",
+              "skip_type_check": false,
+              "key_name": "relevant_blocks",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "A relevant blockhash",
+                  "skip_type_check": false,
+                  "key_name": "blockhash",
+                  "condition": ""
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "true if the scan process was not aborted",
+              "skip_type_check": false,
+              "key_name": "completed",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "when action=='status' and a scan is currently in progress",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Approximate percent complete",
+              "skip_type_check": false,
+              "key_name": "progress",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Height of the block currently being scanned",
+              "skip_type_check": false,
+              "key_name": "current_height",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "True if scan will be aborted (not necessarily before this RPC returns), or false if there is no scan to abort",
+          "skip_type_check": false,
+          "key_name": "success",
+          "condition": "when action=='abort'"
+        }
+      ]
+    },
+    "scantxoutset": {
+      "category": "blockchain",
+      "description": "\nScans the unspent transaction output set for entries that match certain output descriptors.\nExamples of output descriptors are:\n    addr(<address>)                      Outputs whose output script corresponds to the specified address (does not include P2PK)\n    raw(<hex script>)                    Outputs whose output script equals the specified hex-encoded bytes\n    combo(<pubkey>)                      P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH outputs for the given pubkey\n    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys\n    tr(<pubkey>)                         P2TR\n    tr(<pubkey>,{pk(<pubkey>)})          P2TR with single fallback pubkey in tapscript\n    rawtr(<pubkey>)                      P2TR with the specified key as output key rather than inner\n    wsh(and_v(v:pk(<pubkey>),after(2)))  P2WSH miniscript with mandatory pubkey and a timelock\n\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\nor more path elements separated by \"/\", and optionally ending in \"/*\" (unhardened), or \"/*'\" or \"/*h\" (hardened) to specify all\nunhardened or hardened child keys.\nIn the latter case, a range needs to be specified by below if different from 1000.\nFor more information on output descriptors, see the documentation in the doc/descriptors.md file.\n",
+      "examples": "> bitcoin-cli scantxoutset start '[\"raw(76a91411b366edfc0a8b66feebae5c2e25a7b6a5d1cf3188ac)#fm24fxxy\"]'\n> bitcoin-cli scantxoutset status\n> bitcoin-cli scantxoutset abort\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scantxoutset\", \"params\": [\"start\", [\"raw(76a91411b366edfc0a8b66feebae5c2e25a7b6a5d1cf3188ac)#fm24fxxy\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scantxoutset\", \"params\": [\"status\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"scantxoutset\", \"params\": [\"abort\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "scantxoutset",
+      "argument_names": [
+        "action",
+        "scanobjects"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "action"
+          ],
+          "description": "The action to execute\n\"start\" for starting a scan\n\"abort\" for aborting the current scan (returns true when abort was successful)\n\"status\" for progress report (in %) of the current scan",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "scanobjects"
+          ],
+          "description": "Array of scan objects. Required for \"start\" action\nEvery scan object is either a string descriptor or an object:",
+          "oneline_description": "[scanobjects,...]",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "descriptor"
+              ],
+              "description": "An output descriptor",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "An object with output descriptor and metadata",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "An output descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "The range of HD chain indexes to explore (either end or [begin,end])",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": 1000,
+                  "hidden": false,
+                  "type": "range"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "when action=='start'; only returns after scan completes",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "Whether the scan was completed",
+              "skip_type_check": false,
+              "key_name": "success",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The number of unspent transaction outputs scanned",
+              "skip_type_check": false,
+              "key_name": "txouts",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The block height at which the scan was done",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hash of the block at the tip of the chain",
+              "skip_type_check": false,
+              "key_name": "bestblock",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "unspents",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The transaction id",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The vout value",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The output script",
+                      "skip_type_check": false,
+                      "key_name": "scriptPubKey",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "A specialized descriptor for the matched output script",
+                      "skip_type_check": false,
+                      "key_name": "desc",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "The total amount in BTC of the unspent output",
+                      "skip_type_check": false,
+                      "key_name": "amount",
+                      "condition": ""
+                    },
+                    {
+                      "type": "boolean",
+                      "optional": false,
+                      "description": "Whether this is a coinbase output",
+                      "skip_type_check": false,
+                      "key_name": "coinbase",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Height of the unspent transaction output",
+                      "skip_type_check": false,
+                      "key_name": "height",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "Blockhash of the unspent transaction output",
+                      "skip_type_check": false,
+                      "key_name": "blockhash",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Number of confirmations of the unspent transaction output when the scan was done",
+                      "skip_type_check": false,
+                      "key_name": "confirmations",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The total amount of all found unspent outputs in BTC",
+              "skip_type_check": false,
+              "key_name": "total_amount",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "True if scan will be aborted (not necessarily before this RPC returns), or false if there is no scan to abort",
+          "skip_type_check": false,
+          "key_name": "success",
+          "condition": "when action=='abort'"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "when action=='status' and a scan is currently in progress",
+          "inner": [
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Approximate percent complete",
+              "skip_type_check": false,
+              "key_name": "progress",
+              "condition": ""
+            }
+          ]
+        },
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "when action=='status' and no scan is in progress - possibly already completed"
+        }
+      ]
+    },
+    "schema": {
+      "category": "control",
+      "description": "\nReturn RPC command JSON Schema descriptions.\n",
+      "examples": "",
+      "name": "schema",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "FOO",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "send": {
+      "category": "wallet",
+      "description": "\nEXPERIMENTAL warning: this call may be changed in future releases.\n\nSend a transaction.\n",
+      "examples": "\nSend 0.1 BTC with a confirmation target of 6 blocks in economical fee estimate mode\n> bitcoin-cli send '{\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\": 0.1}' 6 economical\n\nSend 0.2 BTC with a fee rate of 1.1 sat/vB using positional arguments\n> bitcoin-cli send '{\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\": 0.2}' null \"unset\" 1.1\n\nSend 0.2 BTC with a fee rate of 1 sat/vB using the options argument\n> bitcoin-cli send '{\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\": 0.2}' null \"unset\" null '{\"fee_rate\": 1}'\n\nSend 0.3 BTC with a fee rate of 25 sat/vB using named arguments\n> bitcoin-cli -named send outputs='{\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\": 0.3}' fee_rate=25\n\nCreate a transaction that should confirm the next block, with a specific input, and return result without adding to wallet or broadcasting to the network\n> bitcoin-cli send '{\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\": 0.1}' 1 economical '{\"add_to_wallet\": false, \"inputs\": [{\"txid\":\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\", \"vout\":1}]}'\n",
+      "name": "send",
+      "argument_names": [
+        "outputs",
+        "conf_target",
+        "estimate_mode",
+        "fee_rate",
+        "add_inputs",
+        "include_unsafe",
+        "minconf",
+        "maxconf",
+        "add_to_wallet",
+        "change_address",
+        "change_position",
+        "change_type",
+        "fee_rate",
+        "include_watching",
+        "inputs",
+        "locktime",
+        "lock_unspents",
+        "psbt",
+        "subtract_fee_from_outputs",
+        "max_tx_weight",
+        "conf_target",
+        "estimate_mode",
+        "replaceable",
+        "solving_data",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "outputs"
+          ],
+          "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nFor convenience, a dictionary, which holds the key-value pairs directly, is also accepted.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "address"
+                  ],
+                  "description": "A key-value pair. The key (string) is the bitcoin address,\nthe value (float or string) is the amount in BTC",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "data"
+                  ],
+                  "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet -txconfirmtarget",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "estimate_mode"
+          ],
+          "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "unset",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "fee_rate"
+          ],
+          "description": "Specify a fee rate in sat/vB.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "not set, fall back to wallet fee estimation",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "add_inputs"
+              ],
+              "description": "Automatically include coins from the wallet to cover the target amount.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "false when \"inputs\" are specified, true otherwise",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "include_unsafe"
+              ],
+              "description": "Include inputs that are not safe to spend (unconfirmed transactions from outside keys and unconfirmed replacement transactions).\nWarning: the resulting transaction may become invalid if one of the unsafe inputs disappears.\nIf that happens, you will need to fund the transaction with different inputs and republish it.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "minconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at least this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "maxconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at most this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "add_to_wallet"
+              ],
+              "description": "When false, returns a serialized transaction which will not be added to the wallet or broadcast",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "change_address"
+              ],
+              "description": "The bitcoin address to receive the change",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "automatic",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "change_position"
+              ],
+              "description": "The index of the change output",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "random",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "change_type"
+              ],
+              "description": "The output type to use. Only valid if change_address is not specified. Options are \"legacy\", \"p2sh-segwit\", \"bech32\" and \"bech32m\".",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "set by -changetype",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "Specify a fee rate in sat/vB.",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "include_watching"
+              ],
+              "description": "Also select inputs which are watch only.\nOnly solvable inputs can be used. Watch-only destinations are solvable if the public key and/or output script was imported,\ne.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "true for watch-only wallets, otherwise false",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "inputs"
+              ],
+              "description": "Specify inputs instead of adding them automatically.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "txid"
+                      ],
+                      "description": "The transaction id",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "hex"
+                    },
+                    {
+                      "names": [
+                        "vout"
+                      ],
+                      "description": "The output number",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "number"
+                    },
+                    {
+                      "names": [
+                        "sequence"
+                      ],
+                      "description": "The sequence number",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "default_hint": "depends on the value of the 'replaceable' and 'locktime' arguments",
+                      "hidden": false,
+                      "type": "number"
+                    },
+                    {
+                      "names": [
+                        "weight"
+                      ],
+                      "description": "The maximum weight for this input, including the weight of the outpoint and sequence number. Note that signature sizes are not guaranteed to be consistent, so the maximum DER signatures size of 73 bytes should be used when considering ECDSA signatures.Remember to convert serialized sizes to weight units when necessary.",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "default_hint": "Calculated from wallet and solving data",
+                      "hidden": false,
+                      "type": "number"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "names": [
+                "locktime"
+              ],
+              "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "lock_unspents"
+              ],
+              "description": "Lock selected unspent outputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "psbt"
+              ],
+              "description": "Always return a PSBT, implies add_to_wallet=false.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "automatic",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "subtract_fee_from_outputs"
+              ],
+              "description": "Outputs to subtract the fee from, specified as integer indices.\nThe fee will be equally deducted from the amount of each specified output.\nThose recipients will receive less bitcoins than you enter in their corresponding amount field.\nIf no outputs are specified here, the sender pays the fee.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    "vout_index"
+                  ],
+                  "description": "The zero-based output index, before a change output is added.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            },
+            {
+              "names": [
+                "max_tx_weight"
+              ],
+              "description": "The maximum acceptable transaction weight.\nTransaction building will fail if this can not be satisfied.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 400000,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet default",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "solving_data"
+              ],
+              "description": "Keys and scripts needed for producing a final transaction with a dummy signature.\nUsed for fee estimation during coin selection.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "pubkeys"
+                  ],
+                  "description": "Public keys involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "pubkey"
+                      ],
+                      "description": "A public key",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "scripts"
+                  ],
+                  "description": "Scripts involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "script"
+                      ],
+                      "description": "A script",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "descriptors"
+                  ],
+                  "description": "Descriptors that provide solving data for this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "descriptor"
+                      ],
+                      "description": "A descriptor",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "If add_to_wallet is false, the hex-encoded raw transaction with signature(s)",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially) signed transaction",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "sendall": {
+      "category": "wallet",
+      "description": "EXPERIMENTAL warning: this call may be changed in future releases.\n\nSpend the value of all (or specific) confirmed UTXOs and unconfirmed change in the wallet to one or more recipients.\nUnconfirmed inbound UTXOs and locked UTXOs will not be spent. Sendall will respect the avoid_reuse wallet flag.\nIf your wallet contains many small inputs, either because it received tiny payments or as a result of accumulating change, consider using `send_max` to exclude inputs that are worth less than the fees needed to spend them.\n",
+      "examples": "\nSpend all UTXOs from the wallet with a fee rate of 1 sat/vB using named arguments\n> bitcoin-cli -named sendall recipients='[\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]' fee_rate=1\n\nSpend all UTXOs with a fee rate of 1.1 sat/vB using positional arguments\n> bitcoin-cli sendall '[\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]' null \"unset\" 1.1\n\nSpend all UTXOs split into equal amounts to two addresses with a fee rate of 1.5 sat/vB using the options argument\n> bitcoin-cli sendall '[\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\", \"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\"]' null \"unset\" null '{\"fee_rate\": 1.5}'\n\nLeave dust UTXOs in wallet, spend only UTXOs with positive effective value with a fee rate of 10 sat/vB using the options argument\n> bitcoin-cli sendall '[\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]' null \"unset\" null '{\"fee_rate\": 10, \"send_max\": true}'\n\nSpend all UTXOs with a fee rate of 1.3 sat/vB using named arguments and sending a 0.25 BTC to another recipient\n> bitcoin-cli -named sendall recipients='[{\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\": 0.25}, \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]' fee_rate=1.3\n\n",
+      "name": "sendall",
+      "argument_names": [
+        "recipients",
+        "conf_target",
+        "estimate_mode",
+        "fee_rate",
+        "add_to_wallet",
+        "fee_rate",
+        "include_watching",
+        "inputs",
+        "locktime",
+        "lock_unspents",
+        "psbt",
+        "send_max",
+        "minconf",
+        "maxconf",
+        "conf_target",
+        "estimate_mode",
+        "replaceable",
+        "solving_data",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "recipients"
+          ],
+          "description": "The sendall destinations. Each address may only appear once.\nOptionally some recipients can be specified with an amount to perform payments, but at least one address must appear without a specified amount.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "address"
+              ],
+              "description": "A bitcoin address which receives an equal share of the unspecified amount.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": true,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "address"
+                  ],
+                  "description": "A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in BTC",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet -txconfirmtarget",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "estimate_mode"
+          ],
+          "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "unset",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "fee_rate"
+          ],
+          "description": "Specify a fee rate in sat/vB.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "not set, fall back to wallet fee estimation",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "add_to_wallet"
+              ],
+              "description": "When false, returns the serialized transaction without broadcasting or adding it to the wallet",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": true,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "Specify a fee rate in sat/vB.",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "include_watching"
+              ],
+              "description": "Also select inputs which are watch-only.\nOnly solvable inputs can be used. Watch-only destinations are solvable if the public key and/or output script was imported,\ne.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "true for watch-only wallets, otherwise false",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "inputs"
+              ],
+              "description": "Use exactly the specified inputs to build the transaction. Specifying inputs is incompatible with the send_max, minconf, and maxconf options.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    ""
+                  ],
+                  "description": "",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "object",
+                  "inner": [
+                    {
+                      "names": [
+                        "txid"
+                      ],
+                      "description": "The transaction id",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "hex"
+                    },
+                    {
+                      "names": [
+                        "vout"
+                      ],
+                      "description": "The output number",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": true,
+                      "hidden": false,
+                      "type": "number"
+                    },
+                    {
+                      "names": [
+                        "sequence"
+                      ],
+                      "description": "The sequence number",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "default_hint": "depends on the value of the 'replaceable' and 'locktime' arguments",
+                      "hidden": false,
+                      "type": "number"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "names": [
+                "locktime"
+              ],
+              "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "lock_unspents"
+              ],
+              "description": "Lock selected unspent outputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "psbt"
+              ],
+              "description": "Always return a PSBT, implies add_to_wallet=false.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "automatic",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "send_max"
+              ],
+              "description": "When true, only use UTXOs that can pay for their own fees to maximize the output amount. When 'false' (default), no UTXO is left behind. send_max is incompatible with providing specific inputs.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "minconf"
+              ],
+              "description": "Require inputs with at least this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "maxconf"
+              ],
+              "description": "Require inputs with at most this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet default",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "solving_data"
+              ],
+              "description": "Keys and scripts needed for producing a final transaction with a dummy signature.\nUsed for fee estimation during coin selection.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "pubkeys"
+                  ],
+                  "description": "Public keys involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "pubkey"
+                      ],
+                      "description": "A public key",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "scripts"
+                  ],
+                  "description": "Scripts involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "script"
+                      ],
+                      "description": "A script",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "descriptors"
+                  ],
+                  "description": "Descriptors that provide solving data for this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "descriptor"
+                      ],
+                      "description": "A descriptor",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "If add_to_wallet is false, the hex-encoded raw transaction with signature(s)",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially) signed transaction",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "sendmany": {
+      "category": "wallet",
+      "description": "Send multiple times. Amounts are double-precision floating point numbers.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "\nSend two amounts to two different addresses:\n> bitcoin-cli sendmany \"\" \"{\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\":0.01,\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\":0.02}\"\n\nSend two amounts to two different addresses setting the confirmation and comment:\n> bitcoin-cli sendmany \"\" \"{\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\":0.01,\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\":0.02}\" 6 \"testing\"\n\nSend two amounts to two different addresses, subtract fee from amount:\n> bitcoin-cli sendmany \"\" \"{\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\":0.01,\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\":0.02}\" 1 \"\" \"[\\\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\\\",\\\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\\\"]\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"sendmany\", \"params\": [\"\", {\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\":0.01,\"bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3\":0.02}, 6, \"testing\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "sendmany",
+      "argument_names": [
+        "dummy",
+        "amounts",
+        "minconf",
+        "comment",
+        "subtractfeefrom",
+        "replaceable",
+        "conf_target",
+        "estimate_mode",
+        "fee_rate",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "dummy"
+          ],
+          "description": "Must be set to \"\" for backwards compatibility.",
+          "oneline_description": "\"\"",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "\"\"",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "amounts"
+          ],
+          "description": "The addresses and amounts",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "address"
+              ],
+              "description": "The bitcoin address is the key, the numeric amount (can be string) in BTC is the value",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": true,
+              "hidden": false,
+              "type": "amount"
+            }
+          ]
+        },
+        {
+          "names": [
+            "minconf"
+          ],
+          "description": "Ignored dummy value",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "comment"
+          ],
+          "description": "A comment",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "subtractfeefrom"
+          ],
+          "description": "The addresses.\nThe fee will be equally deducted from the amount of each selected address.\nThose recipients will receive less bitcoins than you enter in their corresponding amount field.\nIf no addresses are specified here, the sender pays the fee.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "address"
+              ],
+              "description": "Subtract fee from this address",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "names": [
+            "replaceable"
+          ],
+          "description": "Signal that this transaction can be replaced by a transaction (BIP 125)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet default",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet -txconfirmtarget",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "estimate_mode"
+          ],
+          "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "unset",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "fee_rate"
+          ],
+          "description": "Specify a fee rate in sat/vB.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "not set, fall back to wallet fee estimation",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "If true, return extra information about the transaction.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "The transaction id for the send. Only 1 transaction is created regardless of\nthe number of addresses.",
+          "skip_type_check": false,
+          "key_name": "txid",
+          "condition": "if verbose is not set or set to false"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "if verbose is set to true",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id for the send. Only 1 transaction is created regardless of\nthe number of addresses.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The transaction fee reason.",
+              "skip_type_check": false,
+              "key_name": "fee_reason",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "sendmsgtopeer": {
+      "category": "hidden",
+      "description": "Send a p2p message to a peer specified by id.\nThe message type and body must be provided, the message header will be generated.\nThis RPC is for testing only.",
+      "examples": "> bitcoin-cli sendmsgtopeer 0 \"addr\" \"ffffff\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"sendmsgtopeer\", \"params\": [0 \"addr\" \"ffffff\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "sendmsgtopeer",
+      "argument_names": [
+        "peer_id",
+        "msg_type",
+        "msg"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "peer_id"
+          ],
+          "description": "The peer to send the message to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "msg_type"
+          ],
+          "description": "The message type (maximum length 12)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "msg"
+          ],
+          "description": "The serialized message body to send, in hex, without a message header",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "sendrawtransaction": {
+      "category": "rawtransactions",
+      "description": "\nSubmit a raw transaction (serialized, hex-encoded) to local node and network.\n\nThe transaction will be sent unconditionally to all peers, so using sendrawtransaction\nfor manual rebroadcast may degrade privacy by leaking the transaction's origin, as\nnodes will normally not rebroadcast non-wallet transactions already in their mempool.\n\nA specific exception, RPC_TRANSACTION_ALREADY_IN_UTXO_SET, may throw if the transaction cannot be added to the mempool.\n\nRelated RPCs: createrawtransaction, signrawtransactionwithkey\n",
+      "examples": "\nCreate a transaction\n> bitcoin-cli createrawtransaction \"[{\\\"txid\\\" : \\\"mytxid\\\",\\\"vout\\\":0}]\" \"{\\\"myaddress\\\":0.01}\"\nSign the transaction, and get back the hex\n> bitcoin-cli signrawtransactionwithwallet \"myhex\"\n\nSend the transaction (signed hex)\n> bitcoin-cli sendrawtransaction \"signedhex\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"sendrawtransaction\", \"params\": [\"signedhex\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "sendrawtransaction",
+      "argument_names": [
+        "hexstring",
+        "maxfeerate",
+        "maxburnamount"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The hex string of the raw transaction",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "maxfeerate"
+          ],
+          "description": "Reject transactions whose fee rate is higher than the specified value, expressed in BTC/kvB.\nFee rates larger than 1BTC/kvB are rejected.\nSet to 0 to accept any fee rate.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "0.10",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "maxburnamount"
+          ],
+          "description": "Reject transactions with provably unspendable outputs (e.g. 'datacarrier' outputs that use the OP_RETURN opcode) greater than the specified value, expressed in BTC.\nIf burning funds through unspendable outputs is desired, increase this value.\nThis check is based on heuristics and does not guarantee spendability of outputs.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "0.00",
+          "hidden": false,
+          "type": "amount"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "The transaction hash in hex",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "sendtoaddress": {
+      "category": "wallet",
+      "description": "\nSend an amount to a given address.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "\nSend 0.1 BTC\n> bitcoin-cli sendtoaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 0.1\n\nSend 0.1 BTC with a confirmation target of 6 blocks in economical fee estimate mode using positional arguments\n> bitcoin-cli sendtoaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 0.1 \"donation\" \"sean's outpost\" false true 6 economical\n\nSend 0.1 BTC with a fee rate of 1.1 sat/vB, subtract fee from amount, BIP125-replaceable, using positional arguments\n> bitcoin-cli sendtoaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 0.1 \"drinks\" \"room77\" true true null \"unset\" null 1.1\n\nSend 0.2 BTC with a confirmation target of 6 blocks in economical fee estimate mode using named arguments\n> bitcoin-cli -named sendtoaddress address=\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" amount=0.2 conf_target=6 estimate_mode=\"economical\"\n\nSend 0.5 BTC with a fee rate of 25 sat/vB using named arguments\n> bitcoin-cli -named sendtoaddress address=\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" amount=0.5 fee_rate=25\n> bitcoin-cli -named sendtoaddress address=\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" amount=0.5 fee_rate=25 subtractfeefromamount=false replaceable=true avoid_reuse=true comment=\"2 pizzas\" comment_to=\"jeremy\" verbose=true\n",
+      "name": "sendtoaddress",
+      "argument_names": [
+        "address",
+        "amount",
+        "comment",
+        "comment_to",
+        "subtractfeefromamount",
+        "replaceable",
+        "conf_target",
+        "estimate_mode",
+        "avoid_reuse",
+        "fee_rate",
+        "verbose"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address to send to.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "amount"
+          ],
+          "description": "The amount in BTC to send. eg 0.1",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "comment"
+          ],
+          "description": "A comment used to store what the transaction is for.\nThis is not part of the transaction, just kept in your wallet.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "comment_to"
+          ],
+          "description": "A comment to store the name of the person or organization\nto which you're sending the transaction. This is not part of the \ntransaction, just kept in your wallet.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "subtractfeefromamount"
+          ],
+          "description": "The fee will be deducted from the amount being sent.\nThe recipient will receive less bitcoins than you enter in the amount field.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "replaceable"
+          ],
+          "description": "Signal that this transaction can be replaced by a transaction (BIP 125)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet default",
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "conf_target"
+          ],
+          "description": "Confirmation target in blocks",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "wallet -txconfirmtarget",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "estimate_mode"
+          ],
+          "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "unset",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "avoid_reuse"
+          ],
+          "description": "(only available if avoid_reuse wallet flag is set) Avoid spending from dirty addresses; addresses are considered\ndirty if they have previously been used in a transaction. If true, this also activates avoidpartialspends, grouping outputs by their addresses.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "fee_rate"
+          ],
+          "description": "Specify a fee rate in sat/vB.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "not set, fall back to wallet fee estimation",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "verbose"
+          ],
+          "description": "If true, return extra information about the transaction.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "hex",
+          "optional": false,
+          "description": "The transaction id.",
+          "skip_type_check": false,
+          "key_name": "txid",
+          "condition": "if verbose is not set or set to false"
+        },
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "if verbose is set to true",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The transaction id.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The transaction fee reason.",
+              "skip_type_check": false,
+              "key_name": "fee_reason",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "setban": {
+      "category": "network",
+      "description": "\nAttempts to add or remove an IP/Subnet from the banned list.\n",
+      "examples": "> bitcoin-cli setban \"192.168.0.6\" \"add\" 86400\n> bitcoin-cli setban \"192.168.0.0/24\" \"add\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"setban\", \"params\": [\"192.168.0.6\", \"add\", 86400]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "setban",
+      "argument_names": [
+        "subnet",
+        "command",
+        "bantime",
+        "absolute"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "subnet"
+          ],
+          "description": "The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "command"
+          ],
+          "description": "'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "bantime"
+          ],
+          "description": "time in seconds how long (or until when if [absolute] is set) the IP is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "absolute"
+          ],
+          "description": "If set, the bantime must be an absolute timestamp expressed in UNIX epoch time",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "sethdseed": {
+      "category": "wallet",
+      "description": "\nSet or generate a new HD wallet seed. Non-HD wallets will not be upgraded to being a HD wallet. Wallets that are already\nHD will have a new HD seed set so that new keys added to the keypool will be derived from this new seed.\n\nNote that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet seed.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\nNote: This command is only compatible with legacy wallets.\n",
+      "examples": "> bitcoin-cli sethdseed \n> bitcoin-cli sethdseed false\n> bitcoin-cli sethdseed true \"wifkey\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"sethdseed\", \"params\": [true, \"wifkey\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "sethdseed",
+      "argument_names": [
+        "newkeypool",
+        "seed"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "newkeypool"
+          ],
+          "description": "Whether to flush old unused addresses, including change addresses, from the keypool and regenerate it.\nIf true, the next address from getnewaddress and change address from getrawchangeaddress will be from this new seed.\nIf false, addresses (including change addresses if the wallet already had HD Chain Split enabled) from the existing\nkeypool will be used until it has been depleted.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "seed"
+          ],
+          "description": "The WIF private key to use as the new HD seed.\nThe seed value can be retrieved using the dumpwallet command. It is the private key marked hdseed=1",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "random seed",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "setlabel": {
+      "category": "wallet",
+      "description": "\nSets the label associated with the given address.\n",
+      "examples": "> bitcoin-cli setlabel \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" \"tabby\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"setlabel\", \"params\": [\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\", \"tabby\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "setlabel",
+      "argument_names": [
+        "address",
+        "label"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address to be associated with a label.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "label"
+          ],
+          "description": "The label to assign to the address.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "setmocktime": {
+      "category": "hidden",
+      "description": "\nSet the local time to given timestamp (-regtest only)\n",
+      "examples": "",
+      "name": "setmocktime",
+      "argument_names": [
+        "timestamp"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "timestamp"
+          ],
+          "description": "UNIX epoch time\nPass 0 to go back to using the system time.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "setnetworkactive": {
+      "category": "network",
+      "description": "\nDisable/enable all p2p network activity.\n",
+      "examples": "",
+      "name": "setnetworkactive",
+      "argument_names": [
+        "state"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "state"
+          ],
+          "description": "true to enable networking, false to disable",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "The value that was passed in",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "settxfee": {
+      "category": "wallet",
+      "description": "\nSet the transaction fee rate in BTC/kvB for this wallet. Overrides the global -paytxfee command line parameter.\nCan be deactivated by passing 0 as the fee. In that case automatic fee selection will be used by default.\n",
+      "examples": "> bitcoin-cli settxfee 0.00001\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"settxfee\", \"params\": [0.00001]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "settxfee",
+      "argument_names": [
+        "amount"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "amount"
+          ],
+          "description": "The transaction fee rate in BTC/kvB",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "amount"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "Returns true if successful",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "setwalletflag": {
+      "category": "wallet",
+      "description": "\nChange the state of the given wallet flag for a wallet.\n",
+      "examples": "> bitcoin-cli setwalletflag avoid_reuse\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"setwalletflag\", \"params\": [\"avoid_reuse\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "setwalletflag",
+      "argument_names": [
+        "flag",
+        "value"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "flag"
+          ],
+          "description": "The name of the flag to change. Current available flags: avoid_reuse",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "value"
+          ],
+          "description": "The new state.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The name of the flag that was modified",
+              "skip_type_check": false,
+              "key_name": "flag_name",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "The new state of the flag",
+              "skip_type_check": false,
+              "key_name": "flag_state",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "Any warnings associated with the change",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "signmessage": {
+      "category": "wallet",
+      "description": "\nSign a message with the private key of an address\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "\nUnlock the wallet for 30 seconds\n> bitcoin-cli walletpassphrase \"mypassphrase\" 30\n\nCreate the signature\n> bitcoin-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\"\n\nVerify the signature\n> bitcoin-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"signmessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"my message\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "signmessage",
+      "argument_names": [
+        "address",
+        "message"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address to use for the private key.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "message"
+          ],
+          "description": "The message to create a signature of.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The signature of the message encoded in base 64",
+          "skip_type_check": false,
+          "key_name": "signature",
+          "condition": ""
+        }
+      ]
+    },
+    "signmessagewithprivkey": {
+      "category": "util",
+      "description": "\nSign a message with the private key of an address\n",
+      "examples": "\nCreate the signature\n> bitcoin-cli signmessagewithprivkey \"privkey\" \"my message\"\n\nVerify the signature\n> bitcoin-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"signmessagewithprivkey\", \"params\": [\"privkey\", \"my message\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "signmessagewithprivkey",
+      "argument_names": [
+        "privkey",
+        "message"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "privkey"
+          ],
+          "description": "The private key to sign the message with.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "message"
+          ],
+          "description": "The message to create a signature of.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The signature of the message encoded in base 64",
+          "skip_type_check": false,
+          "key_name": "signature",
+          "condition": ""
+        }
+      ]
+    },
+    "signrawtransactionwithkey": {
+      "category": "rawtransactions",
+      "description": "\nSign inputs for raw transaction (serialized, hex-encoded).\nThe second argument is an array of base58-encoded private\nkeys that will be the only keys used to sign the transaction.\nThe third optional argument (may be null) is an array of previous transaction outputs that\nthis transaction depends on but may not yet be in the block chain.\n",
+      "examples": "> bitcoin-cli signrawtransactionwithkey \"myhex\" \"[\\\"key1\\\",\\\"key2\\\"]\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"signrawtransactionwithkey\", \"params\": [\"myhex\", \"[\\\"key1\\\",\\\"key2\\\"]\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "signrawtransactionwithkey",
+      "argument_names": [
+        "hexstring",
+        "privkeys",
+        "prevtxs",
+        "sighashtype"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The transaction hex string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "privkeys"
+          ],
+          "description": "The base58-encoded private keys for signing",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "privatekey"
+              ],
+              "description": "private key in base58-encoding",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "prevtxs"
+          ],
+          "description": "The previous dependent transaction outputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "scriptPubKey"
+                  ],
+                  "description": "output script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "redeemScript"
+                  ],
+                  "description": "(required for P2SH) redeem script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "witnessScript"
+                  ],
+                  "description": "(required for P2WSH or P2SH-P2WSH) witness script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "amount"
+                  ],
+                  "description": "(required for Segwit inputs) the amount spent",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "sighashtype"
+          ],
+          "description": "The signature hash type. Must be one of:\n       \"DEFAULT\"\n       \"ALL\"\n       \"NONE\"\n       \"SINGLE\"\n       \"ALL|ANYONECANPAY\"\n       \"NONE|ANYONECANPAY\"\n       \"SINGLE|ANYONECANPAY\"\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "DEFAULT for Taproot, ALL otherwise",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hex-encoded raw transaction with signature(s)",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Script verification errors (if there are any)",
+              "skip_type_check": false,
+              "key_name": "errors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hash of the referenced, previous transaction",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The index of the output to spent and used as input",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "witness",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "witness",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hex-encoded signature script",
+                      "skip_type_check": false,
+                      "key_name": "scriptSig",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Script sequence number",
+                      "skip_type_check": false,
+                      "key_name": "sequence",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "Verification or signing error related to the input",
+                      "skip_type_check": false,
+                      "key_name": "error",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "signrawtransactionwithwallet": {
+      "category": "wallet",
+      "description": "\nSign inputs for raw transaction (serialized, hex-encoded).\nThe second optional argument (may be null) is an array of previous transaction outputs that\nthis transaction depends on but may not yet be in the block chain.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "> bitcoin-cli signrawtransactionwithwallet \"myhex\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"signrawtransactionwithwallet\", \"params\": [\"myhex\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "signrawtransactionwithwallet",
+      "argument_names": [
+        "hexstring",
+        "prevtxs",
+        "sighashtype"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexstring"
+          ],
+          "description": "The transaction hex string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "prevtxs"
+          ],
+          "description": "The previous dependent transaction outputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "scriptPubKey"
+                  ],
+                  "description": "The output script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "redeemScript"
+                  ],
+                  "description": "(required for P2SH) redeem script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "witnessScript"
+                  ],
+                  "description": "(required for P2WSH or P2SH-P2WSH) witness script",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "amount"
+                  ],
+                  "description": "(required for Segwit inputs) the amount spent",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "sighashtype"
+          ],
+          "description": "The signature hash type. Must be one of\n       \"DEFAULT\"\n       \"ALL\"\n       \"NONE\"\n       \"SINGLE\"\n       \"ALL|ANYONECANPAY\"\n       \"NONE|ANYONECANPAY\"\n       \"SINGLE|ANYONECANPAY\"",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "DEFAULT for Taproot, ALL otherwise",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The hex-encoded raw transaction with signature(s)",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Script verification errors (if there are any)",
+              "skip_type_check": false,
+              "key_name": "errors",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hash of the referenced, previous transaction",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "The index of the output to spent and used as input",
+                      "skip_type_check": false,
+                      "key_name": "vout",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "",
+                      "skip_type_check": false,
+                      "key_name": "witness",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "",
+                          "skip_type_check": false,
+                          "key_name": "witness",
+                          "condition": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The hex-encoded signature script",
+                      "skip_type_check": false,
+                      "key_name": "scriptSig",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": false,
+                      "description": "Script sequence number",
+                      "skip_type_check": false,
+                      "key_name": "sequence",
+                      "condition": ""
+                    },
+                    {
+                      "type": "string",
+                      "optional": false,
+                      "description": "Verification or signing error related to the input",
+                      "skip_type_check": false,
+                      "key_name": "error",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "simulaterawtransaction": {
+      "category": "wallet",
+      "description": "\nCalculate the balance change resulting in the signing and broadcasting of the given transaction(s).\n",
+      "examples": "> bitcoin-cli simulaterawtransaction [\"myhex\"]\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"simulaterawtransaction\", \"params\": [[\"myhex\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "simulaterawtransaction",
+      "argument_names": [
+        "rawtxs",
+        "include_watchonly",
+        "options"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "rawtxs"
+          ],
+          "description": "An array of hex strings of raw transactions.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "rawtx"
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "include_watchonly"
+              ],
+              "description": "Whether to include watch-only addresses (see RPC importaddress)",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "true for watch-only wallets, otherwise false",
+              "hidden": false,
+              "type": "boolean"
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "The wallet balance change (negative means decrease).",
+              "skip_type_check": false,
+              "key_name": "balance_change",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "stop": {
+      "category": "control",
+      "description": "\nRequest a graceful shutdown of Bitcoin Core.",
+      "examples": "",
+      "name": "stop",
+      "argument_names": [
+        "wait"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "wait"
+          ],
+          "description": "how long to wait in ms",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": true,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "A string with the content 'Bitcoin Core stopping'",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "submitblock": {
+      "category": "mining",
+      "description": "\nAttempts to submit new block to network.\nSee https://en.bitcoin.it/wiki/BIP_0022 for full specification.\n",
+      "examples": "> bitcoin-cli submitblock \"mydata\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"submitblock\", \"params\": [\"mydata\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "submitblock",
+      "argument_names": [
+        "hexdata",
+        "dummy"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexdata"
+          ],
+          "description": "the hex-encoded block data to submit",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "dummy"
+          ],
+          "description": "dummy value, for compatibility with BIP22. This value is ignored.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "ignored",
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "If the block was accepted"
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "description": "According to BIP22",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "Otherwise"
+        }
+      ]
+    },
+    "submitheader": {
+      "category": "mining",
+      "description": "\nDecode the given hexdata as a header and submit it as a candidate chain tip if valid.\nThrows when the header is invalid.\n",
+      "examples": "> bitcoin-cli submitheader \"aabbcc\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"submitheader\", \"params\": [\"aabbcc\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "submitheader",
+      "argument_names": [
+        "hexdata"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "hexdata"
+          ],
+          "description": "the hex-encoded block header data",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "None",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "submitpackage": {
+      "category": "rawtransactions",
+      "description": "Submit a package of raw transactions (serialized, hex-encoded) to local node.\nThe package will be validated according to consensus and mempool policy rules. If any transaction passes, it will be accepted to mempool.\nThis RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md for documentation on package policies.\nWarning: successful submission does not mean the transactions will propagate throughout the network.\n",
+      "examples": "> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"submitpackage\", \"params\": [[\"raw-parent-tx-1\", \"raw-parent-tx-2\", \"raw-child-tx\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n> bitcoin-cli submitpackage '[\"raw-tx-without-unconfirmed-parents\"]'\n",
+      "name": "submitpackage",
+      "argument_names": [
+        "package",
+        "maxfeerate",
+        "maxburnamount"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "package"
+          ],
+          "description": "An array of raw transactions.\nThe package must solely consist of a child transaction and all of its unconfirmed parents, if any. None of the parents may depend on each other.\nThe package must be topologically sorted, with the child being the last element in the array.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "rawtx"
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "maxfeerate"
+          ],
+          "description": "Reject transactions whose fee rate is higher than the specified value, expressed in BTC/kvB.\nFee rates larger than 1BTC/kvB are rejected.\nSet to 0 to accept any fee rate.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "0.10",
+          "hidden": false,
+          "type": "amount"
+        },
+        {
+          "names": [
+            "maxburnamount"
+          ],
+          "description": "Reject transactions with provably unspendable outputs (e.g. 'datacarrier' outputs that use the OP_RETURN opcode) greater than the specified value, expressed in BTC.\nIf burning funds through unspendable outputs is desired, increase this value.\nThis check is based on heuristics and does not guarantee spendability of outputs.\n",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "0.00",
+          "hidden": false,
+          "type": "amount"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The transaction package result message. \"success\" indicates all transactions were accepted into or are already in the mempool.",
+              "skip_type_check": false,
+              "key_name": "package_msg",
+              "condition": ""
+            },
+            {
+              "type": "object",
+              "optional": false,
+              "description": "transaction results keyed by wtxid",
+              "skip_type_check": false,
+              "key_name": "tx-results",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "object",
+                  "optional": false,
+                  "description": "transaction wtxid",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "hex",
+                      "optional": false,
+                      "description": "The transaction hash in hex",
+                      "skip_type_check": false,
+                      "key_name": "txid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "hex",
+                      "optional": true,
+                      "description": "The wtxid of a different transaction with the same txid but different witness found in the mempool. This means the submitted transaction was ignored.",
+                      "skip_type_check": false,
+                      "key_name": "other-wtxid",
+                      "condition": ""
+                    },
+                    {
+                      "type": "number",
+                      "optional": true,
+                      "description": "Sigops-adjusted virtual transaction size.",
+                      "skip_type_check": false,
+                      "key_name": "vsize",
+                      "condition": ""
+                    },
+                    {
+                      "type": "object",
+                      "optional": true,
+                      "description": "Transaction fees",
+                      "skip_type_check": false,
+                      "key_name": "fees",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "amount",
+                          "optional": false,
+                          "description": "transaction fee in BTC",
+                          "skip_type_check": false,
+                          "key_name": "base",
+                          "condition": ""
+                        },
+                        {
+                          "type": "amount",
+                          "optional": true,
+                          "description": "if the transaction was not already in the mempool, the effective feerate in BTC per KvB. For example, the package feerate and/or feerate with modified fees from prioritisetransaction.",
+                          "skip_type_check": false,
+                          "key_name": "effective-feerate",
+                          "condition": ""
+                        },
+                        {
+                          "type": "array",
+                          "optional": true,
+                          "description": "if effective-feerate is provided, the wtxids of the transactions whose fees and vsizes are included in effective-feerate.",
+                          "skip_type_check": false,
+                          "key_name": "effective-includes",
+                          "condition": "",
+                          "inner": [
+                            {
+                              "type": "hex",
+                              "optional": false,
+                              "description": "transaction wtxid in hex",
+                              "skip_type_check": false,
+                              "key_name": "",
+                              "condition": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "optional": true,
+                      "description": "The transaction error string, if it was rejected by the mempool",
+                      "skip_type_check": false,
+                      "key_name": "error",
+                      "condition": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "List of txids of replaced transactions",
+              "skip_type_check": false,
+              "key_name": "replaced-transactions",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction id",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "syncwithvalidationinterfacequeue": {
+      "category": "hidden",
+      "description": "\nWaits for the validation interface queue to catch up on everything that was there when we entered this function.\n",
+      "examples": "> bitcoin-cli syncwithvalidationinterfacequeue \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"syncwithvalidationinterfacequeue\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "syncwithvalidationinterfacequeue",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "testmempoolaccept": {
+      "category": "rawtransactions",
+      "description": "\nReturns result of mempool acceptance tests indicating if raw transaction(s) (serialized, hex-encoded) would be accepted by mempool.\n\nIf multiple transactions are passed in, parents must come before children and package policies apply: the transactions cannot conflict with any mempool transactions or each other.\n\nIf one transaction fails, other transactions may not be fully validated (the 'allowed' key will be blank).\n\nThe maximum number of transactions allowed is 25.\n\nThis checks if transactions violate the consensus or policy rules.\n\nSee sendrawtransaction call.\n",
+      "examples": "\nCreate a transaction\n> bitcoin-cli createrawtransaction \"[{\\\"txid\\\" : \\\"mytxid\\\",\\\"vout\\\":0}]\" \"{\\\"myaddress\\\":0.01}\"\nSign the transaction, and get back the hex\n> bitcoin-cli signrawtransactionwithwallet \"myhex\"\n\nTest acceptance of the transaction (signed hex)\n> bitcoin-cli testmempoolaccept '[\"signedhex\"]'\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"testmempoolaccept\", \"params\": [[\"signedhex\"]]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "testmempoolaccept",
+      "argument_names": [
+        "rawtxs",
+        "maxfeerate"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "rawtxs"
+          ],
+          "description": "An array of hex strings of raw transactions.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                "rawtx"
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "hex"
+            }
+          ]
+        },
+        {
+          "names": [
+            "maxfeerate"
+          ],
+          "description": "Reject transactions whose fee rate is higher than the specified value, expressed in BTC/kvB.\nFee rates larger than 1BTC/kvB are rejected.\nSet to 0 to accept any fee rate.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "0.10",
+          "hidden": false,
+          "type": "amount"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "The result of the mempool acceptance test for each raw transaction in the input array.\nReturns results for each transaction in the same order they were passed in.\nTransactions that cannot be fully validated due to failures in other transactions will not contain an 'allowed' result.\n",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "object",
+              "optional": false,
+              "description": "",
+              "skip_type_check": false,
+              "key_name": "",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "txid",
+                  "condition": ""
+                },
+                {
+                  "type": "hex",
+                  "optional": false,
+                  "description": "The transaction witness hash in hex",
+                  "skip_type_check": false,
+                  "key_name": "wtxid",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "Package validation error, if any (only possible if rawtxs had more than 1 transaction).",
+                  "skip_type_check": false,
+                  "key_name": "package-error",
+                  "condition": ""
+                },
+                {
+                  "type": "boolean",
+                  "optional": true,
+                  "description": "Whether this tx would be accepted to the mempool and pass client-specified maxfeerate. If not present, the tx was not fully validated due to a failure in another tx in the list.",
+                  "skip_type_check": false,
+                  "key_name": "allowed",
+                  "condition": ""
+                },
+                {
+                  "type": "number",
+                  "optional": true,
+                  "description": "Virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted (only present when 'allowed' is true)",
+                  "skip_type_check": false,
+                  "key_name": "vsize",
+                  "condition": ""
+                },
+                {
+                  "type": "object",
+                  "optional": true,
+                  "description": "Transaction fees (only present if 'allowed' is true)",
+                  "skip_type_check": false,
+                  "key_name": "fees",
+                  "condition": "",
+                  "inner": [
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "transaction fee in BTC",
+                      "skip_type_check": false,
+                      "key_name": "base",
+                      "condition": ""
+                    },
+                    {
+                      "type": "amount",
+                      "optional": false,
+                      "description": "the effective feerate in BTC per KvB. May differ from the base feerate if, for example, there are modified fees from prioritisetransaction or a package feerate was used.",
+                      "skip_type_check": false,
+                      "key_name": "effective-feerate",
+                      "condition": ""
+                    },
+                    {
+                      "type": "array",
+                      "optional": false,
+                      "description": "transactions whose fees and vsizes are included in effective-feerate.",
+                      "skip_type_check": false,
+                      "key_name": "effective-includes",
+                      "condition": "",
+                      "inner": [
+                        {
+                          "type": "hex",
+                          "optional": false,
+                          "description": "transaction wtxid in hex",
+                          "skip_type_check": false,
+                          "key_name": "",
+                          "condition": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "Rejection reason (only present when 'allowed' is false)",
+                  "skip_type_check": false,
+                  "key_name": "reject-reason",
+                  "condition": ""
+                },
+                {
+                  "type": "string",
+                  "optional": true,
+                  "description": "Rejection details (only present when 'allowed' is false and rejection details exist)",
+                  "skip_type_check": false,
+                  "key_name": "reject-details",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "unloadwallet": {
+      "category": "wallet",
+      "description": "Unloads the wallet referenced by the request endpoint, otherwise unloads the wallet specified in the argument.\nSpecifying the wallet name on a wallet endpoint is invalid.",
+      "examples": "> bitcoin-cli unloadwallet wallet_name\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"unloadwallet\", \"params\": [wallet_name]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "unloadwallet",
+      "argument_names": [
+        "wallet_name",
+        "load_on_startup"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "wallet_name"
+          ],
+          "description": "The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "the wallet name from the RPC endpoint",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "load_on_startup"
+          ],
+          "description": "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Warning messages, if any, related to unloading the wallet.",
+              "skip_type_check": false,
+              "key_name": "warnings",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "string",
+                  "optional": false,
+                  "description": "",
+                  "skip_type_check": false,
+                  "key_name": "",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "upgradewallet": {
+      "category": "wallet",
+      "description": "\nUpgrade the wallet. Upgrades to the latest version if no version number is specified.\nNew keys may be generated and a new wallet backup will need to be made.",
+      "examples": "> bitcoin-cli upgradewallet 169900\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"upgradewallet\", \"params\": [169900]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "upgradewallet",
+      "argument_names": [
+        "version"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "version"
+          ],
+          "description": "The version number to upgrade to. Default is the latest wallet version.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 169900,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "Name of wallet this operation was performed on",
+              "skip_type_check": false,
+              "key_name": "wallet_name",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Version of wallet before this operation",
+              "skip_type_check": false,
+              "key_name": "previous_version",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Version of wallet after this operation",
+              "skip_type_check": false,
+              "key_name": "current_version",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "Description of result, if no error",
+              "skip_type_check": false,
+              "key_name": "result",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "Error message (if there is one)",
+              "skip_type_check": false,
+              "key_name": "error",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "uptime": {
+      "category": "control",
+      "description": "\nReturns the total uptime of the server.\n",
+      "examples": "> bitcoin-cli uptime \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"uptime\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "uptime",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "number",
+          "optional": false,
+          "description": "The number of seconds that the server has been running",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "utxoupdatepsbt": {
+      "category": "rawtransactions",
+      "description": "\nUpdates all segwit inputs and outputs in a PSBT with data from output descriptors, the UTXO set, txindex, or the mempool.\n",
+      "examples": "> bitcoin-cli utxoupdatepsbt \"psbt\"\n",
+      "name": "utxoupdatepsbt",
+      "argument_names": [
+        "psbt",
+        "descriptors"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "A base64 string of a PSBT",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "descriptors"
+          ],
+          "description": "An array of either strings or objects",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "An output descriptor",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "An object with an output descriptor and extra information",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "desc"
+                  ],
+                  "description": "An output descriptor",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "string"
+                },
+                {
+                  "names": [
+                    "range"
+                  ],
+                  "description": "Up to what index HD chains should be explored (either end or [begin,end])",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": 1000,
+                  "hidden": false,
+                  "type": "range"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "results": [
+        {
+          "type": "string",
+          "optional": false,
+          "description": "The base64-encoded partially signed transaction with inputs updated",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "validateaddress": {
+      "category": "util",
+      "description": "\nReturn information about the given bitcoin address.\n",
+      "examples": "> bitcoin-cli validateaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"validateaddress\", \"params\": [\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "validateaddress",
+      "argument_names": [
+        "address"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address to validate",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the address is valid or not",
+              "skip_type_check": false,
+              "key_name": "isvalid",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "The bitcoin address validated",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex-encoded output script generated by the address",
+              "skip_type_check": false,
+              "key_name": "scriptPubKey",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "If the key is a script",
+              "skip_type_check": false,
+              "key_name": "isscript",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": true,
+              "description": "If the address is a witness address",
+              "skip_type_check": false,
+              "key_name": "iswitness",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": true,
+              "description": "The version number of the witness program",
+              "skip_type_check": false,
+              "key_name": "witness_version",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex value of the witness program",
+              "skip_type_check": false,
+              "key_name": "witness_program",
+              "condition": ""
+            },
+            {
+              "type": "string",
+              "optional": true,
+              "description": "Error message, if any",
+              "skip_type_check": false,
+              "key_name": "error",
+              "condition": ""
+            },
+            {
+              "type": "array",
+              "optional": true,
+              "description": "Indices of likely error locations in address, if known (e.g. Bech32 errors)",
+              "skip_type_check": false,
+              "key_name": "error_locations",
+              "condition": "",
+              "inner": [
+                {
+                  "type": "number",
+                  "optional": false,
+                  "description": "index of a potential error",
+                  "skip_type_check": false,
+                  "key_name": "index",
+                  "condition": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "verifychain": {
+      "category": "blockchain",
+      "description": "\nVerifies blockchain database.\n",
+      "examples": "> bitcoin-cli verifychain \n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"verifychain\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "verifychain",
+      "argument_names": [
+        "checklevel",
+        "nblocks"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "checklevel"
+          ],
+          "description": "How thorough the block verification is:\n- level 0 reads the blocks from disk\n- level 1 verifies block validity\n- level 2 verifies undo data\n- level 3 checks disconnection of tip blocks\n- level 4 tries to reconnect the blocks\n- each level includes the checks of the previous levels",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "3, range=0-4",
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "nblocks"
+          ],
+          "description": "The number of blocks to check.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default_hint": "6, 0=all",
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "Verification finished successfully. If false, check debug.log for reason.",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "verifymessage": {
+      "category": "util",
+      "description": "Verify a signed message.",
+      "examples": "\nUnlock the wallet for 30 seconds\n> bitcoin-cli walletpassphrase \"mypassphrase\" 30\n\nCreate the signature\n> bitcoin-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\"\n\nVerify the signature\n> bitcoin-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"\n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"verifymessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"signature\", \"my message\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "verifymessage",
+      "argument_names": [
+        "address",
+        "signature",
+        "message"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "The bitcoin address to use for the signature.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "signature"
+          ],
+          "description": "The signature provided by the signer in base 64 encoding (see signmessage).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "message"
+          ],
+          "description": "The message that was signed.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "boolean",
+          "optional": false,
+          "description": "If the signature is verified or not.",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "verifytxoutproof": {
+      "category": "blockchain",
+      "description": "\nVerifies that a proof points to a transaction in a block, returning the transaction it commits to\nand throwing an RPC error if the block is not in our best chain\n",
+      "examples": "",
+      "name": "verifytxoutproof",
+      "argument_names": [
+        "proof"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "proof"
+          ],
+          "description": "The hex-encoded proof generated by gettxoutproof",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        }
+      ],
+      "results": [
+        {
+          "type": "array",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The txid(s) which the proof commits to, or empty array if the proof cannot be validated.",
+              "skip_type_check": false,
+              "key_name": "txid",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "waitforblock": {
+      "category": "hidden",
+      "description": "\nWaits for a specific new block and returns useful info about it.\n\nReturns the current block on timeout or exit.\n\nMake sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli waitforblock \"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\" 1000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"waitforblock\", \"params\": [\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\", 1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "waitforblock",
+      "argument_names": [
+        "blockhash",
+        "timeout"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "blockhash"
+          ],
+          "description": "Block hash to wait for.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "hex"
+        },
+        {
+          "names": [
+            "timeout"
+          ],
+          "description": "Time in milliseconds to wait for a response. 0 indicates no timeout.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The blockhash",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Block height",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "waitforblockheight": {
+      "category": "hidden",
+      "description": "\nWaits for (at least) block height and returns the height and hash\nof the current tip.\n\nReturns the current block on timeout or exit.\n\nMake sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli waitforblockheight 100 1000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"waitforblockheight\", \"params\": [100, 1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "waitforblockheight",
+      "argument_names": [
+        "height",
+        "timeout"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "height"
+          ],
+          "description": "Block height to wait for.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "timeout"
+          ],
+          "description": "Time in milliseconds to wait for a response. 0 indicates no timeout.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The blockhash",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Block height",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "waitfornewblock": {
+      "category": "hidden",
+      "description": "\nWaits for any new block and returns useful info about it.\n\nReturns the current block on timeout or exit.\n\nMake sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+      "examples": "> bitcoin-cli waitfornewblock 1000\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"waitfornewblock\", \"params\": [1000]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "waitfornewblock",
+      "argument_names": [
+        "timeout"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "timeout"
+          ],
+          "description": "Time in milliseconds to wait for a response. 0 indicates no timeout.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "hex",
+              "optional": false,
+              "description": "The blockhash",
+              "skip_type_check": false,
+              "key_name": "hash",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "Block height",
+              "skip_type_check": false,
+              "key_name": "height",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "walletcreatefundedpsbt": {
+      "category": "wallet",
+      "description": "\nCreates and funds a transaction in the Partially Signed Transaction format.\nImplements the Creator and Updater roles.\nAll existing inputs must either have their previous output transaction be in the wallet\nor be in the UTXO set. Solving data must be provided for non-wallet inputs.\n",
+      "examples": "\nCreate a transaction with no inputs\n> bitcoin-cli walletcreatefundedpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"\n",
+      "name": "walletcreatefundedpsbt",
+      "argument_names": [
+        "inputs",
+        "outputs",
+        "locktime",
+        "add_inputs",
+        "include_unsafe",
+        "minconf",
+        "maxconf",
+        "changeAddress",
+        "changePosition",
+        "change_type",
+        "includeWatching",
+        "lockUnspents",
+        "fee_rate",
+        "feeRate",
+        "subtractFeeFromOutputs",
+        "max_tx_weight",
+        "conf_target",
+        "estimate_mode",
+        "replaceable",
+        "solving_data",
+        "options",
+        "bip32derivs"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "inputs"
+          ],
+          "description": "Leave empty to add inputs automatically. See add_inputs option.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "txid"
+                  ],
+                  "description": "The transaction id",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                },
+                {
+                  "names": [
+                    "vout"
+                  ],
+                  "description": "The output number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "sequence"
+                  ],
+                  "description": "The sequence number",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default_hint": "depends on the value of the 'locktime' and 'options.replaceable' arguments",
+                  "hidden": false,
+                  "type": "number"
+                },
+                {
+                  "names": [
+                    "weight"
+                  ],
+                  "description": "The maximum weight for this input, including the weight of the outpoint and sequence number. Note that signature sizes are not guaranteed to be consistent, so the maximum DER signatures size of 73 bytes should be used when considering ECDSA signatures.Remember to convert serialized sizes to weight units when necessary.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default_hint": "Calculated from wallet and solving data",
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "outputs"
+          ],
+          "description": "The outputs specified as key-value pairs.\nEach key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.\nAt least one output of either type must be specified.\nFor compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\naccepted as second parameter.",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "array",
+          "inner": [
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "address"
+                  ],
+                  "description": "A key-value pair. The key (string) is the bitcoin address,\nthe value (float or string) is the amount in BTC",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "amount"
+                }
+              ]
+            },
+            {
+              "names": [
+                ""
+              ],
+              "description": "",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "data"
+                  ],
+                  "description": "A key-value pair. The key must be \"data\", the value is hex-encoded data",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": true,
+                  "hidden": false,
+                  "type": "hex"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "locktime"
+          ],
+          "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": 0,
+          "hidden": false,
+          "type": "number"
+        },
+        {
+          "names": [
+            "options"
+          ],
+          "description": "",
+          "oneline_description": "options",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "hidden": false,
+          "type": "object",
+          "inner": [
+            {
+              "names": [
+                "add_inputs"
+              ],
+              "description": "Automatically include coins from the wallet to cover the target amount.\n",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "false when \"inputs\" are specified, true otherwise",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "include_unsafe"
+              ],
+              "description": "Include inputs that are not safe to spend (unconfirmed transactions from outside keys and unconfirmed replacement transactions).\nWarning: the resulting transaction may become invalid if one of the unsafe inputs disappears.\nIf that happens, you will need to fund the transaction with different inputs and republish it.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "minconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at least this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 0,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "maxconf"
+              ],
+              "description": "If add_inputs is specified, require inputs with at most this many confirmations.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "changeAddress"
+              ],
+              "description": "The bitcoin address to receive the change",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "automatic",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "changePosition"
+              ],
+              "description": "The index of the change output",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "random",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "change_type"
+              ],
+              "description": "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\".",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "set by -changetype",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "includeWatching"
+              ],
+              "description": "Also select inputs which are watch only",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "true for watch-only wallets, otherwise false",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "lockUnspents"
+              ],
+              "description": "Lock selected unspent outputs",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": false,
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "fee_rate"
+              ],
+              "description": "Specify a fee rate in sat/vB.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "feeRate"
+              ],
+              "description": "Specify a fee rate in BTC/kvB.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "not set, fall back to wallet fee estimation",
+              "hidden": false,
+              "type": "amount"
+            },
+            {
+              "names": [
+                "subtractFeeFromOutputs"
+              ],
+              "description": "The outputs to subtract the fee from.\nThe fee will be equally deducted from the amount of each specified output.\nThose recipients will receive less bitcoins than you enter in their corresponding amount field.\nIf no outputs are specified here, the sender pays the fee.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": [],
+              "hidden": false,
+              "type": "array",
+              "inner": [
+                {
+                  "names": [
+                    "vout_index"
+                  ],
+                  "description": "The zero-based output index, before a change output is added.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "hidden": false,
+                  "type": "number"
+                }
+              ]
+            },
+            {
+              "names": [
+                "max_tx_weight"
+              ],
+              "description": "The maximum acceptable transaction weight.\nTransaction building will fail if this can not be satisfied.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default": 400000,
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "conf_target"
+              ],
+              "description": "Confirmation target in blocks",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet -txconfirmtarget",
+              "hidden": false,
+              "type": "number"
+            },
+            {
+              "names": [
+                "estimate_mode"
+              ],
+              "description": "The fee estimate mode, must be one of (case insensitive):\nunset, economical, conservative \nunset means no mode set (economical mode is used if the transaction is replaceable;\notherwise, conservative mode is used). \neconomical estimates use a shorter time horizon, making them more\nresponsive to short-term drops in the prevailing fee market. This mode\npotentially returns a lower fee rate estimate.\nconservative estimates use a longer time horizon, making them\nless responsive to short-term drops in the prevailing fee market. This mode\npotentially returns a higher fee rate estimate.\n",
+              "oneline_description": "",
+              "also_positional": true,
+              "type_str": [],
+              "required": false,
+              "default": "unset",
+              "hidden": false,
+              "type": "string"
+            },
+            {
+              "names": [
+                "replaceable"
+              ],
+              "description": "Marks this transaction as BIP125-replaceable.\nAllows this transaction to be replaced by a transaction with higher fees",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "default_hint": "wallet default",
+              "hidden": false,
+              "type": "boolean"
+            },
+            {
+              "names": [
+                "solving_data"
+              ],
+              "description": "Keys and scripts needed for producing a final transaction with a dummy signature.\nUsed for fee estimation during coin selection.",
+              "oneline_description": "",
+              "also_positional": false,
+              "type_str": [],
+              "required": false,
+              "hidden": false,
+              "type": "object",
+              "inner": [
+                {
+                  "names": [
+                    "pubkeys"
+                  ],
+                  "description": "Public keys involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "pubkey"
+                      ],
+                      "description": "A public key",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "scripts"
+                  ],
+                  "description": "Scripts involved in this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "script"
+                      ],
+                      "description": "A script",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "hex"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "descriptors"
+                  ],
+                  "description": "Descriptors that provide solving data for this transaction.",
+                  "oneline_description": "",
+                  "also_positional": false,
+                  "type_str": [],
+                  "required": false,
+                  "default": [],
+                  "hidden": false,
+                  "type": "array",
+                  "inner": [
+                    {
+                      "names": [
+                        "descriptor"
+                      ],
+                      "description": "A descriptor",
+                      "oneline_description": "",
+                      "also_positional": false,
+                      "type_str": [],
+                      "required": false,
+                      "hidden": false,
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "names": [
+            "bip32derivs"
+          ],
+          "description": "Include BIP 32 derivation paths for public keys if we know them",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The resulting raw transaction (base64-encoded string)",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            },
+            {
+              "type": "amount",
+              "optional": false,
+              "description": "Fee in BTC the resulting transaction pays",
+              "skip_type_check": false,
+              "key_name": "fee",
+              "condition": ""
+            },
+            {
+              "type": "number",
+              "optional": false,
+              "description": "The position of the added change output, or -1",
+              "skip_type_check": false,
+              "key_name": "changepos",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "walletdisplayaddress": {
+      "category": "wallet",
+      "description": "Display address on an external signer for verification.",
+      "examples": "",
+      "name": "walletdisplayaddress",
+      "argument_names": [
+        "address"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "address"
+          ],
+          "description": "bitcoin address to display",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The address as confirmed by the signer",
+              "skip_type_check": false,
+              "key_name": "address",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    },
+    "walletlock": {
+      "category": "wallet",
+      "description": "\nRemoves the wallet encryption key from memory, locking the wallet.\nAfter calling this method, you will need to call walletpassphrase again\nbefore being able to call any methods which require the wallet to be unlocked.\n",
+      "examples": "\nSet the passphrase for 2 minutes to perform a transaction\n> bitcoin-cli walletpassphrase \"my pass phrase\" 120\n\nPerform a send (requires passphrase set)\n> bitcoin-cli sendtoaddress \"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\" 1.0\n\nClear the passphrase since we are done before 2 minutes is up\n> bitcoin-cli walletlock \n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"walletlock\", \"params\": []}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "walletlock",
+      "argument_names": [],
+      "arguments": [],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "walletpassphrase": {
+      "category": "wallet",
+      "description": "\nStores the wallet decryption key in memory for 'timeout' seconds.\nThis is needed prior to performing transactions related to private keys such as sending bitcoins\n\nNote:\nIssuing the walletpassphrase command while the wallet is already unlocked will set a new unlock\ntime that overrides the old one.\n",
+      "examples": "\nUnlock the wallet for 60 seconds\n> bitcoin-cli walletpassphrase \"my pass phrase\" 60\n\nLock the wallet again (before 60 seconds)\n> bitcoin-cli walletlock \n\nAs a JSON-RPC call\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"walletpassphrase\", \"params\": [\"my pass phrase\", 60]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "walletpassphrase",
+      "argument_names": [
+        "passphrase",
+        "timeout"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "passphrase"
+          ],
+          "description": "The wallet passphrase",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "timeout"
+          ],
+          "description": "The time to keep the decryption key in seconds; capped at 100000000 (~3 years).",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "number"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "walletpassphrasechange": {
+      "category": "wallet",
+      "description": "\nChanges the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.\n",
+      "examples": "> bitcoin-cli walletpassphrasechange \"old one\" \"new one\"\n> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\": \"curltest\", \"method\": \"walletpassphrasechange\", \"params\": [\"old one\", \"new one\"]}' -H 'content-type: application/json' http://127.0.0.1:8332/\n",
+      "name": "walletpassphrasechange",
+      "argument_names": [
+        "oldpassphrase",
+        "newpassphrase"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "oldpassphrase"
+          ],
+          "description": "The current passphrase",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "newpassphrase"
+          ],
+          "description": "The new passphrase",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "type": "none",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": ""
+        }
+      ]
+    },
+    "walletprocesspsbt": {
+      "category": "wallet",
+      "description": "\nUpdate a PSBT with input information from our wallet and then sign inputs\nthat we can sign for.\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n",
+      "examples": "> bitcoin-cli walletprocesspsbt \"psbt\"\n",
+      "name": "walletprocesspsbt",
+      "argument_names": [
+        "psbt",
+        "sign",
+        "sighashtype",
+        "bip32derivs",
+        "finalize"
+      ],
+      "arguments": [
+        {
+          "names": [
+            "psbt"
+          ],
+          "description": "The transaction base64 string",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": true,
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "sign"
+          ],
+          "description": "Also sign the transaction when updating (requires wallet to be unlocked)",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "sighashtype"
+          ],
+          "description": "The signature hash type to sign with if not specified by the PSBT. Must be one of\n       \"DEFAULT\"\n       \"ALL\"\n       \"NONE\"\n       \"SINGLE\"\n       \"ALL|ANYONECANPAY\"\n       \"NONE|ANYONECANPAY\"\n       \"SINGLE|ANYONECANPAY\"",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": "DEFAULT for Taproot, ALL otherwise",
+          "hidden": false,
+          "type": "string"
+        },
+        {
+          "names": [
+            "bip32derivs"
+          ],
+          "description": "Include BIP 32 derivation paths for public keys if we know them",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        },
+        {
+          "names": [
+            "finalize"
+          ],
+          "description": "Also finalize inputs if possible",
+          "oneline_description": "",
+          "also_positional": false,
+          "type_str": [],
+          "required": false,
+          "default": true,
+          "hidden": false,
+          "type": "boolean"
+        }
+      ],
+      "results": [
+        {
+          "type": "object",
+          "optional": false,
+          "description": "",
+          "skip_type_check": false,
+          "key_name": "",
+          "condition": "",
+          "inner": [
+            {
+              "type": "string",
+              "optional": false,
+              "description": "The base64-encoded partially signed transaction",
+              "skip_type_check": false,
+              "key_name": "psbt",
+              "condition": ""
+            },
+            {
+              "type": "boolean",
+              "optional": false,
+              "description": "If the transaction has a complete set of signatures",
+              "skip_type_check": false,
+              "key_name": "complete",
+              "condition": ""
+            },
+            {
+              "type": "hex",
+              "optional": true,
+              "description": "The hex-encoded network transaction if complete",
+              "skip_type_check": false,
+              "key_name": "hex",
+              "condition": ""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -271,6 +271,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/node.cpp
   rpc/output_script.cpp
   rpc/rawtransaction.cpp
+  rpc/schema.cpp
   rpc/server.cpp
   rpc/server_util.cpp
   rpc/signmessage.cpp

--- a/src/rpc/schema.cpp
+++ b/src/rpc/schema.cpp
@@ -1,0 +1,220 @@
+#include <rpc/schema.h>
+
+#include <rpc/server.h>
+#include <rpc/util.h>
+#include <univalue.h>
+#include <util/string.h>
+
+using util::SplitString;
+
+// Notes
+// =====
+//
+// This file implements the `schema` RPC. See `Schema::Commands` for the entry
+// point. This RPC is intended to facilite writing code generators which can
+// generate Bitcoin Core RPC clients in other languages. It is as
+// self-contained as possible in this file, to facilitate back-porting to older
+// versions and rebasing onto newer versions.
+//
+// We should probably use something like Open RPC, but the Bitcoin Core RPC API
+// is weird enough that this may be difficult.
+//
+// The returned JSON includes all avaialable information about the RPC, whether
+// useful to external callers or not. There is certainly more detail than
+// necessary, and some of it should probably be elided.
+//
+// The top level type is a map of strings to `vector<CRPCCommand>`. This is
+// because commands can have aliases, at least according to the types. However,
+// I haven't actually seen one, so we just assert that there are no aliases so
+// we don't have to worry about it.
+
+class Schema {
+public:
+    static UniValue Commands(const std::map<std::string, std::vector<const CRPCCommand*>>& commands) {
+        UniValue value{UniValue::VOBJ};
+
+        UniValue rpcs{UniValue::VOBJ};
+
+        for (const auto& entry: commands) {
+            assert(entry.second.size() == 1);
+
+            const auto& command = entry.second[0];
+
+            RPCHelpMan rpc = ((RpcMethodFnType)command->unique_id)();
+
+            rpcs.pushKV(entry.first, Schema::Command(command->category, rpc, command->argNames));
+        }
+
+        value.pushKV("rpcs", rpcs);
+
+        return value;
+    }
+
+private:
+    static UniValue Argument(const RPCArg& argument) {
+        UniValue value{UniValue::VOBJ};
+
+        UniValue names{UniValue::VARR};
+        for (auto const& name: SplitString(argument.m_names, '|')) {
+            names.push_back(name);
+        }
+        value.pushKV("names", names);
+
+        value.pushKV("description", argument.m_description);
+
+        value.pushKV("oneline_description", argument.m_opts.oneline_description);
+
+        value.pushKV("also_positional", argument.m_opts.also_positional);
+
+        UniValue type_str{UniValue::VARR};
+        for (auto const& str: argument.m_opts.type_str) {
+            type_str.push_back(str);
+        }
+        value.pushKV("type_str", type_str);
+
+        bool required = std::holds_alternative<RPCArg::Optional>(argument.m_fallback)
+            && std::get<RPCArg::Optional>(argument.m_fallback) == RPCArg::Optional::NO;
+
+        value.pushKV("required", required);
+
+        if (std::holds_alternative<UniValue>(argument.m_fallback)) {
+            value.pushKV("default", std::get<UniValue>(argument.m_fallback));
+        }
+
+        if (std::holds_alternative<std::string>(argument.m_fallback)) {
+            value.pushKV("default_hint", std::get<std::string>(argument.m_fallback));
+        }
+
+        value.pushKV("hidden", argument.m_opts.hidden);
+
+        value.pushKV("type", Schema::ArgumentType(argument.m_type));
+
+        UniValue inner{UniValue::VARR};
+        for (auto const& argument: argument.m_inner) {
+            inner.push_back(Schema::Argument(argument));
+        }
+        if (!inner.empty()) {
+            value.pushKV("inner", inner);
+        }
+
+        return value;
+    }
+
+    static std::string ArgumentType(const RPCArg::Type& type) {
+        switch (type) {
+            case RPCArg::Type::AMOUNT:
+                return "amount";
+            case RPCArg::Type::ARR:
+                return "array";
+            case RPCArg::Type::BOOL:
+                return "boolean";
+            case RPCArg::Type::NUM:
+                return "number";
+            case RPCArg::Type::OBJ:
+                return "object";
+            case RPCArg::Type::OBJ_NAMED_PARAMS:
+                return "object";
+            case RPCArg::Type::OBJ_USER_KEYS:
+                return "object";
+            case RPCArg::Type::RANGE:
+                return "range";
+            case RPCArg::Type::STR:
+                return "string";
+            case RPCArg::Type::STR_HEX:
+                return "hex";
+            default:
+                NONFATAL_UNREACHABLE();
+        }
+    }
+
+    static UniValue Command(
+        const std::string& category,
+        const RPCHelpMan& command,
+        const std::vector<std::pair<std::string, bool>>& argNames
+    ) {
+        UniValue value{UniValue::VOBJ};
+
+        value.pushKV("category", category);
+        value.pushKV("description", command.m_description);
+        value.pushKV("examples", command.m_examples.m_examples);
+        value.pushKV("name", command.m_name);
+
+        UniValue argument_names{UniValue::VARR};
+        for (const auto& pair : argNames) {
+            UniValue argument_name{UniValue::VARR};
+            argument_names.push_back(pair.first);
+        }
+        value.pushKV("argument_names", argument_names);
+
+        UniValue arguments{UniValue::VARR};
+        for (const auto& argument : command.m_args) {
+            arguments.push_back(Schema::Argument(argument));
+        }
+        value.pushKV("arguments", arguments);
+
+        UniValue results{UniValue::VARR};
+        for (const auto& result : command.m_results.m_results) {
+            results.push_back(Schema::Result(result));
+        }
+        value.pushKV("results", results);
+
+        return value;
+    }
+
+    static UniValue Result(const RPCResult& result) {
+        UniValue value{UniValue::VOBJ};
+        value.pushKV("type", Schema::ResultType(result.m_type));
+        value.pushKV("optional", result.m_optional);
+        value.pushKV("description", result.m_description);
+        value.pushKV("skip_type_check", result.m_skip_type_check);
+        value.pushKV("key_name", result.m_key_name);
+        value.pushKV("condition", result.m_cond);
+
+        UniValue inner{UniValue::VARR};
+        for (auto const& result: result.m_inner) {
+            inner.push_back(Schema::Result(result));
+        }
+        if (!inner.empty()) {
+            value.pushKV("inner", inner);
+        }
+
+        return value;
+    }
+
+    static std::string ResultType(const RPCResult::Type& type) {
+        switch (type) {
+            case RPCResult::Type::OBJ:
+                return "object";
+            case RPCResult::Type::ARR:
+                return "array";
+            case RPCResult::Type::STR:
+                return "string";
+            case RPCResult::Type::NUM:
+                return "number";
+            case RPCResult::Type::BOOL:
+                return "boolean";
+            case RPCResult::Type::NONE:
+                return "none";
+            case RPCResult::Type::ANY:
+                return "any";
+            case RPCResult::Type::STR_AMOUNT:
+                return "amount";
+            case RPCResult::Type::STR_HEX:
+                return "hex";
+            case RPCResult::Type::OBJ_DYN:
+                return "object";
+            case RPCResult::Type::ARR_FIXED:
+                return "object";
+            case RPCResult::Type::NUM_TIME:
+                return "timestamp";
+            case RPCResult::Type::ELISION:
+                return "elision";
+            default:
+                NONFATAL_UNREACHABLE();
+        }
+    }
+};
+
+UniValue CommandSchemas(const std::map<std::string, std::vector<const CRPCCommand*>>& commands) {
+    return Schema::Commands(commands);
+}

--- a/src/rpc/schema.h
+++ b/src/rpc/schema.h
@@ -1,0 +1,15 @@
+#ifndef BITCOIN_RPC_SCHEMA_H
+#define BITCOIN_RPC_SCHEMA_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+class CRPCCommand;
+class UniValue;
+
+class Schema;
+
+UniValue CommandSchemas(const std::map<std::string, std::vector<const CRPCCommand*>>& commands);
+
+#endif // BITCOIN_RPC_SCHEMA_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -12,6 +12,7 @@
 #include <logging.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>
+#include <rpc/schema.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>
 #include <sync.h>
@@ -124,6 +125,12 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
     return strRet;
 }
 
+UniValue CRPCTable::schema() const
+{
+    return CommandSchemas(this->mapCommands);
+}
+
+
 static RPCHelpMan help()
 {
     return RPCHelpMan{"help",
@@ -148,6 +155,22 @@ static RPCHelpMan help()
     }
 
     return tableRPC.help(strCommand, jsonRequest);
+},
+    };
+}
+
+static RPCHelpMan schema()
+{
+    return RPCHelpMan{"schema",
+                "\nReturn RPC command JSON Schema descriptions.\n",
+                {},
+                {
+                    RPCResult{RPCResult::Type::OBJ, "", "FOO"},
+                },
+                RPCExamples{""},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& jsonRequest) -> UniValue
+{
+    return tableRPC.schema();
 },
     };
 }
@@ -246,6 +269,7 @@ static const CRPCCommand vRPCCommands[]{
     /* Overall control/query calls */
     {"control", &getrpcinfo},
     {"control", &help},
+    {"control", &schema},
     {"control", &stop},
     {"control", &uptime},
 };

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -164,6 +164,8 @@ public:
      */
     void appendCommand(const std::string& name, const CRPCCommand* pcmd);
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
+
+    UniValue schema() const;
 };
 
 bool IsDeprecatedRPCEnabled(const std::string& method);

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -12,6 +12,7 @@
 #include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
+#include <rpc/schema.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <uint256.h>
@@ -503,6 +504,7 @@ private:
     R ArgValue(size_t i) const;
     //! Return positional index of a parameter using its name as key.
     size_t GetParamIndex(std::string_view key) const;
+    friend Schema;
 };
 
 /**


### PR DESCRIPTION
Implements a `schema` RPC. See `Schema::Commands` for the entry point. This RPC is intended to facilite writing code generators which can generate Bitcoin Core RPC clients in other languages. It is as self-contained as possible in this file, to facilitate back-porting to older versions and rebasing onto newer versions.

We should probably use something like Open RPC, but the Bitcoin Core RPC API is weird enough that this may be difficult.

The returned JSON includes all avaialable information about the RPC, whether useful to external callers or not. There is certainly more detail than necessary, and some of it should probably be elided.

The top level type is a map of strings to `vector<CRPCCommand>`. This is because commands can have aliases, at least according to the types. However, I haven't actually seen one, so we just assert that there are no aliases so we don't have to worry about it.

The output is [here](https://github.com/casey/bitcoin/blob/9d90e50d191330237688eea1a4bd93018b417da2/schema.json).